### PR TITLE
Print errors if present when calling YouTube API

### DIFF
--- a/iSponsorBlockTV/api_helpers.py
+++ b/iSponsorBlockTV/api_helpers.py
@@ -21,6 +21,11 @@ async def get_vid_id(title, artist, api_key, web_session):
     url = constants.Youtube_api + "search"
     async with web_session.get(url, params=params) as resp:
         data = await resp.json()
+        
+    if "error" in data:
+        print(data["error"])
+        return
+
     for i in data["items"]:
         title_api = html.unescape(i["snippet"]["title"])
         artist_api = html.unescape(i["snippet"]["channelTitle"])


### PR DESCRIPTION
All of my API calls were showing as errors in the Google console.
Printing them helps with troubleshooting.

Some examples:
```python
{'code': 403, 'message': 'The request cannot be completed because you have exceeded your <a href="/youtube/v3/getting-started#quota">quota</a>.', 'errors': [{'message': 'The request cannot be completed because you have exceeded your <a href="/youtube/v3/getting-started#quota">quota</a>.', 'domain': 'youtube.quota', 'reason': 'quotaExceeded'}]}
```

```python
{'code': 403, 'message': 'Requests to this API youtube method youtube.api.v3.V3DataSearchService.List are blocked.', 'errors': [{'message': 'Requests to this API youtube method youtube.api.v3.V3DataSearchService.List are blocked.', 'domain': 'global', 'reason': 'forbidden'}], 'status': 'PERMISSION_DENIED', 'details': [{'@type': 'type.googleapis.com/google.rpc.ErrorInfo', 'reason': 'API_KEY_SERVICE_BLOCKED', 'domain': 'googleapis.com', 'metadata': {'service': 'youtube.googleapis.com', 'consumer': 'projects/XXXXXXXXXX'}}]}
```