### PR TITLE
Allow comma separated categories

### DIFF
--- a/iSponsorBlockTV/config_setup.py
+++ b/iSponsorBlockTV/config_setup.py
@@ -102,9 +102,10 @@ def main(config, config_file, debug):
     if skip_categories != []:
         if input("Skip categories already specified. Change them? (y/n) ") == "y":
             categories = input(
-                "Enter skip categories (space sepparated)(don't add a comma in between) Options: [sponsor selfpromo exclusive_access interaction poi_highlight intro outro preview filler music_offtopic:\n"
+                "Enter skip categories (space or comma sepparated) Options: [sponsor selfpromo exclusive_access interaction poi_highlight intro outro preview filler music_offtopic:\n"
             )
-            skip_categories = categories.split(" ")
+            skip_categories = categories.replace(",", " ").split(" ")
+            skip_categories = [x for x in skip_categories if x != ''] # Remove empty strings
     else:
         categories = input(
             "Enter skip categories (space sepparated) Options: [sponsor, selfpromo, exclusive_access, interaction, poi_highlight, intro, outro, preview, filler, music_offtopic:\n"


### PR DESCRIPTION
Allows to specify categories separating them using both commas and spaces to prevent confusion from users.