### PR TITLE
Check tvOS instead of specific atv models

### DIFF
--- a/iSponsorBlockTV/config_setup.py
+++ b/iSponsorBlockTV/config_setup.py
@@ -1,7 +1,7 @@
 import pyatv
 import json
 import asyncio
-from pyatv.const import DeviceModel
+from pyatv.const import OperatingSystem
 import sys
 import aiohttp
 import asyncio
@@ -28,12 +28,7 @@ async def find_atvs(loop):
     atvs = []
     for i in devices:
         # Only get Apple TV's
-        if i.device_info.model in [
-            DeviceModel.Gen4,
-            DeviceModel.Gen4K,
-            DeviceModel.AppleTV4KGen2,
-        ]:
-            # if i.device_info.model in [DeviceModel.AppleTV4KGen2]: #FOR TESTING
+        if i.device_info.operating_system == OperatingSystem.TvOS:
             if input("Found {}. Do you want to add it? (y/n) ".format(i.name)) == "y":
 
                 identifier = i.identifier

--- a/iSponsorBlockTV/config_setup.py
+++ b/iSponsorBlockTV/config_setup.py
@@ -30,7 +30,7 @@ async def find_atvs(loop):
         # Only get Apple TV's
         if (
           i.device_info.operating_system == OperatingSystem.TvOS
-          and input("Found {}. Do you want to add it? (y/n) ".format(i.name)) == "y"
+          and input(f"Found {i.name}. Do you want to add it? (y/n) ") == "y"
         ):
             identifier = i.identifier
 


### PR DESCRIPTION
Check the operating system is tvOS instead of specific Apple TV models.

iSponsorBlockTV currently doesn't support the `AppleTV4kGen3` as that model is not checked for here. Checking the operating system instead will mean this will no longer need to be updated to support future Apple TV models. Currently have a PR to add the model in pyatv: https://github.com/postlund/pyatv/pull/2013

Fixes #36, #38