### PR TITLE
temp fix for miniaudio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+miniaudio==1.57
 pyatv
 aiohttp
 aiodns


### PR DESCRIPTION
GitHub actions always rebuilds miniaudio (which is needed by pyatv). It, however, always uses the latest released version. Since the current miniaudio version (1.58) is broken (does not build), it breaks workflows. 

Temporarily add "miniaudio==1.57" to "requirements.txt" for fix it.