### PR TITLE
Add Google TV status to README

### DIFF
--- a/.github/workflows/update_docker_readme.yml
+++ b/.github/workflows/update_docker_readme.yml
@@ -25,6 +25,6 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: dmunozv04/isponsorblocktv
           short-description: ${{ github.event.repository.description }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Open an issue/pull request if you have tested a device that isn't listed here.
 | Google TV          |   ✅    |
 | Roku               |   ❔    |
 | Fire TV            |   ❔    |
+| CCwGTV             |   ✅    |
 | Nintendo Switch    |   ✅    |
 | Xbox One/Series    |   ❔    |
 | Playstation 4/5    |   ✅    |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Open an issue/pull request if you have tested a device that isn't listed here.
 | LG TV (WebOS)      |   ✅    |
 | Android TV         |   ❔    |
 | Chromecast         |   ❔    |
+| Google TV          |   ✅    |
 | Roku               |   ❔    |
 | Fire TV            |   ❔    |
 | Nintendo Switch    |   ✅    |


### PR DESCRIPTION
I tested this on the Chromecast with Google TV.

The CCwGTV is quite different from older Chromecasts. It runs on a branded version of Android TV. So we could mark compatibility w/ Android TV. I'm like 90% sure it would work, but I don't actually have something with a branded "Android TV" OS so I can't be sure

Initially I was going to mark Chromecast as compatible, but I'm getting some errors on my older Chromecast 4K (which does not use Android TV). I'll open an issue for that (or a PR if I can figure it out).

Note that there is an older platform called "Google TV" that is unrelated. It was retired 10 years ago, but could cause confusion. Could use the phrase "Chromecast with Google TV" but I didn't want to make the table wider. The initialism `CCwGTV` is pretty well known, so could use that instead.