### PR TITLE
Fix segment UUID concatenation

### DIFF
--- a/iSponsorBlockTV/api_helpers.py
+++ b/iSponsorBlockTV/api_helpers.py
@@ -138,7 +138,7 @@ class ApiHelper:
                         segment_dict["start"] - segment_before_end < 1
                 ):  # Less than 1 second appart, combine them and skip them together
                     segment_dict["start"] = segment_before_start
-                    segment_dict["UUID"].append(segment_before_UUID)
+                    segment_dict["UUID"].extend(segment_before_UUID)
                     segments.pop()
                 segments.append(segment_dict)
         except Exception:


### PR DESCRIPTION
Fixes #66 

Before, the whole UUID list would get added to the UUID list instead of just its members, resulting in nested lists, e.g.

```
segments = [{'start': 53.495, 'end': 61.544, 'UUID': ['3ff36ef516888600471f1a03338b2faa5972f1bc26a2da038983cb549f4e9af96']}, {'start': 598.649, 'end': 321.091, 'UUID': ['f5dac489d7bff2bbbc8b1cde89c8d2485a3979b227542cf34de133a7ab1963fb6', ['97489095d68cc9448b3a8a7e8379cf746b2ac9fdf94e917c9f24b9162f02d5b96', ['9e7cdc02c4495f7480f0792e005d29374e47d1fc99d7e3a57b16b53d958a8d166', ['9e1217491467df90bc592be7133dc2549b7cd55d4d280c4241c86dcd7e3e36cb6']]]]}]
```

With this change, just the UUID values themselves are added to the list, e.g.
```
segments = [{'start': 53.495, 'end': 61.544, 'UUID': ['3ff36ef516888600471f1a03338b2faa5972f1bc26a2da038983cb549f4e9af96']}, {'start': 598.649, 'end': 321.091, 'UUID': ['f5dac489d7bff2bbbc8b1cde89c8d2485a3979b227542cf34de133a7ab1963fb6', '97489095d68cc9448b3a8a7e8379cf746b2ac9fdf94e917c9f24b9162f02d5b96', '9e7cdc02c4495f7480f0792e005d29374e47d1fc99d7e3a57b16b53d958a8d166', '9e1217491467df90bc592be7133dc2549b7cd55d4d280c4241c86dcd7e3e36cb6']}]
```