### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore files
+.dockerignore
+.gitignore
+.deepsource.toml
+.github
+
+Dockerfile
+docker-compose.yml
+README.md


### PR DESCRIPTION
This file is needed to avoid copying useless files inside the docker image.