### PR TITLE
Confirm Xbox Compatability. Clarify TV Code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ Open an issue/pull request if you have tested a device that isn't listed here.
 | Fire TV            |   ✅    |
 | CCwGTV             |   ✅    |
 | Nintendo Switch    |   ✅    |
-| Xbox One/Series    |   ❔    |
+| Xbox One/Series    |   ✅    |
 | Playstation 4/5    |   ✅    |
 
 ## Usage
 Run iSponsorBlockTV on a computer that has network access.
 Auto discovery will require the computer to be on the same network as the device during setup.
+The device can also be manually added to iSponsorBlockTV with a YouTube TV code. This code can be found in the settings page of your YouTube application.
 
 It connects to the device, watches its activity and skips any sponsor segment using the [SponsorBlock](https://sponsor.ajay.app/) API.
 It can also skip/mute YouTube ads.


### PR DESCRIPTION
I have been able to confirm the application as working on the Xbox Series S and have marked it accordingly. 

I also initially avoided the TV Code since I hadn't used YouTube TV codes before and incorrectly assumed it was only applicable to SmartTVs. I've also added clarification to the Usage explaining that it is found in the settings of the YouTube app. Feel free to exclude that from the pull request if you see fit. 