### PR TITLE
Attempt to fix ad skips

### DIFF
--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -70,12 +70,16 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             if self.mute_ads and data.get("state", "0") == "1":
                 # print("Ad has ended, unmuting")
                 create_task(self.mute(False, override=True))
-        elif self.mute_ads and event_type == "onAdStateChange":
+        elif event_type == "onAdStateChange":
             data = args[0]
             if data["adState"] == '0':  # Ad is not playing
                 # print("Ad has ended, unmuting")
                 create_task(self.mute(False, override=True))
-            else:  # Seen multiple other adStates, assuming they are all ads
+            elif self.skip_ads and data["isSkipEnabled"] == "true":  # YouTube uses strings for booleans
+                print("Ad can be skipped, skipping")
+                create_task(self.skip_ad())
+                create_task(self.mute(False, override=True))
+            elif self.mute_ads:  # Seen multiple other adStates, assuming they are all ads
                 print("Ad has started, muting")
                 create_task(self.mute(True, override=True))
         # Manages volume, useful since YouTube wants to know the volume when unmuting (even if they already have it)
@@ -96,13 +100,8 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             if vid_id := data["contentVideoId"]:
                 print(f"Getting segments for next video: {vid_id}")
                 create_task(self.api_helper.get_segments(vid_id))
-
-            if data["isSkippable"] == "true":  # YouTube uses strings for booleans
-                if self.skip_ads:
-                    create_task(self.skip_ad())
-                    create_task(self.mute(False, override=True))
-                elif self.mute_ads:
-                    create_task(self.mute(True, override=True))
+            if self.mute_ads:
+                create_task(self.mute(True, override=True))
 
         elif event_type == "loungeStatus":
             data = args[0]


### PR DESCRIPTION
Youtube has "fixed" the glitch that allowed ads to be skipped the moment they started. This fixes the issue by waiting until the skip button is visible to skip the ad