### PR TITLE
Fix list_to_tuple

### DIFF
--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -10,9 +10,9 @@ from .conditional_ttl_cache import AsyncConditionalTTL
 
 def list_to_tuple(function):
     def wrapper(*args):
-        args = [tuple(x) if x is list else x for x in args]
+        args = [tuple(x) if isinstance(x, list) else x for x in args]
         result = function(*args)
-        result = tuple(result) if result is list else result
+        result = tuple(result) if isinstance(result, list) else result
         return result
 
     return wrapper


### PR DESCRIPTION
Instead of using is, we should use isinstance() which is the correct way to check the type of an object in Python.