### PR TITLE
fix for overlapping segments

### DIFF
--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -153,9 +153,9 @@ class ApiHelper:
         segments = []
         ignore_ttl = True
         try:
-            response_segments = response["segments"]            
+            response_segments = response["segments"]
             # sort by end
-            response_segments = sorted(response_segments, key = lambda x: x["segment"][1])
+            response_segments = sorted(response_segments, key=lambda x: x["segment"][1])
             # extend ends of overlapping segments to make one big segment
             for i in response_segments:
                 for j in response_segments:
@@ -163,7 +163,7 @@ class ApiHelper:
                         i["segment"][1] = j["segment"][1]
 
             # sort by start
-            response_segments = sorted(response_segments, key = lambda x: x["segment"][0])
+            response_segments = sorted(response_segments, key=lambda x: x["segment"][0])
             # extend starts of overlapping segments to make one big segment
             for i in response_segments:
                 for j in response_segments:

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -153,7 +153,24 @@ class ApiHelper:
         segments = []
         ignore_ttl = True
         try:
-            for i in response["segments"]:
+            response_segments = response["segments"]            
+            # sort by end
+            response_segments = sorted(response_segments, key = lambda x: x["segment"][1])
+            # extend ends of overlapping segments to make one big segment
+            for i in response_segments:
+                for j in response_segments:
+                    if j["segment"][0] <= i["segment"][1] <= j["segment"][1]:
+                        i["segment"][1] = j["segment"][1]
+
+            # sort by start
+            response_segments = sorted(response_segments, key = lambda x: x["segment"][0])
+            # extend starts of overlapping segments to make one big segment
+            for i in response_segments:
+                for j in response_segments:
+                    if j["segment"][0] <= i["segment"][0] <= j["segment"][1]:
+                        i["segment"][0] = j["segment"][0]
+
+            for i in response_segments:
                 ignore_ttl = (
                     ignore_ttl and i["locked"] == 1
                 )  # If all segments are locked, ignore ttl

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -155,7 +155,7 @@ class ApiHelper:
         try:
             response_segments = response["segments"]
             # sort by end
-            response_segments = sorted(response_segments, key=lambda x: x["segment"][1])
+            response_segments.sort(key=lambda x: x["segment"][1])
             # extend ends of overlapping segments to make one big segment
             for i in response_segments:
                 for j in response_segments:
@@ -163,10 +163,10 @@ class ApiHelper:
                         i["segment"][1] = j["segment"][1]
 
             # sort by start
-            response_segments = sorted(response_segments, key=lambda x: x["segment"][0])
+            response_segments.sort(key=lambda x: x["segment"][0])
             # extend starts of overlapping segments to make one big segment
-            for i in response_segments:
-                for j in response_segments:
+            for i in reversed(response_segments):
+                for j in reversed(response_segments):
                     if j["segment"][0] <= i["segment"][0] <= j["segment"][1]:
                         i["segment"][0] = j["segment"][0]
 


### PR DESCRIPTION
Justification:
this LTT video https://www.youtube.com/watch?v=t78p50s32HY
The API returns overlapping and unsorted segments for it.
```
    {'videoID': 't78p50s32HY', 'segments': [
            {'category': 'sponsor', 'actionType': 'skip', 'segment': [
                    37.66,
                    55.37
                ], 'UUID': '828805118ad2388407040305918f78341d92ce72dcb6bfe76ce4a26c0588b6307', 'videoDuration': 1748.881, 'locked': 1, 'votes': 6, 'description': ''
            },
            {'category': 'selfpromo', 'actionType': 'skip', 'segment': [
                    35.5,
                    38.56
                ], 'UUID': 'cb5ebe38c679cb24ccee4c546beae4eaf251e74a1530827ab9b98a2de847eef77', 'videoDuration': 1748.881, 'locked': 1, 'votes': 1, 'description': ''
            },
            {'category': 'selfpromo', 'actionType': 'skip', 'segment': [
                    354.755,
                    360.392
                ], 'UUID': '93e68895dc66bb21844ab9f566180b9d8072268c936024785eb35f3898a1abbc7', 'videoDuration': 1748.881, 'locked': 1, 'votes': 1, 'description': ''
            },
            {'category': 'selfpromo', 'actionType': 'skip', 'segment': [
                    630.721,
                    635.194
                ], 'UUID': '3509e1012f3977cfc0337d5a5865cd2a44fa87474eaa3f1fae638cf90f5229ae7', 'videoDuration': 1748.881, 'locked': 1, 'votes': 1, 'description': ''
            },
            {'category': 'selfpromo', 'actionType': 'skip', 'segment': [
                    1489.18,
                    1507.632
                ], 'UUID': 'f845f7c977e7e0ae7c495d91e95e5ac0b98187edf5e59ef02b97f0f81afb072d7', 'videoDuration': 1748.881, 'locked': 1, 'votes': 1, 'description': ''
            },
            {'category': 'sponsor', 'actionType': 'skip', 'segment': [
                    1644.07,
                    1721.17
                ], 'UUID': '4a1ab3c9650aa26199d55d824d1bfc3938c4e348fd5e57a1ae8b3d109f55d6cc7', 'videoDuration': 1748.881, 'locked': 1, 'votes': 1, 'description': ''
            },
            {'category': 'outro', 'actionType': 'skip', 'segment': [
                    1720.92,
                    1748.881
                ], 'UUID': '107dadfbfcf1058b0d23b89b2333c0b39aa6407037f9149d13f46d3e3bd95dfe7', 'videoDuration': 1748.881, 'locked': 0, 'votes': 0, 'description': ''
            }
        ]
    }
```
Note how the first two segments overlap and also are not in the correct order.
This causes this code here https://github.com/dmunozv04/iSponsorBlockTV/blob/a75dd83548421023165f3fe3fe100de995de784d/src/iSponsorBlockTV/api_helpers.py#L172 to get confused and instead of one big segment `[35.5, 55.37]` we end up with one very small segment `[37.66, 38.56]`

The proposed fix should take care of all kinds of overlapping segments. Even segment "chains" like `[startA, startB, endA, startC, endB, endC]`. Those should be merged into one big segment as well.
Then the segments will go to the next step sorted by start, so that part will not get confused any more either and will also remove the duplicates created by the first two steps.