### PR TITLE
Fix deps permissions in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ COPY requirements.txt .
 
 RUN apk add --no-cache gcc musl-dev && \
     pip install --upgrade pip wheel && \
-    pip install --user -r requirements.txt && \
+    pip install -r requirements.txt && \
     pip uninstall -y pip wheel && \
     apk del gcc musl-dev && \
-    python3 -m compileall -b -f /root/.local/lib/python3.11/site-packages && \
-    find /root/.local/lib/python3.11/site-packages -name "*.py" -type f -delete && \
-    find /root/.local/lib/python3.11/ -name "__pycache__" -type d -exec rm -rf {} +
+    python3 -m compileall -b -f /usr/local/lib/python3.11/site-packages && \
+    find /usr/local/lib/python3.11/site-packages -name "*.py" -type f -delete && \
+    find /usr/local/lib/python3.11/ -name "__pycache__" -type d -exec rm -rf {} +
 
 FROM base
 
@@ -29,7 +29,7 @@ ENV PIP_NO_CACHE_DIR=off iSPBTV_docker=True iSPBTV_data_dir=data TERM=xterm-256c
 
 COPY requirements.txt .
 
-COPY --from=dep_installer /root/.local /root/.local
+COPY --from=dep_installer /usr/local /usr/local
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes #164

Do not install dependencies under `/root` and revert compile path from `/root/.local/` -> `/usr/local/`.

Dependencies were being installed for under `/root` causing the following error when the docker container is run with a non `root` user:
```
Traceback (most recent call last):

  File "./main.py", line 1, in <module>

  File "./iSponsorBlockTV/helpers.py", line 8, in <module>

ModuleNotFoundError: No module named 'appdirs'
```