### PR TITLE
Add the ability to specify a custom API server

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -18,5 +18,6 @@
         {"id": "",
         "name": ""
         }
-    ]
+    ],
+    "api_server": "https://sponsor.ajay.app"
 }

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -27,6 +27,7 @@ class ApiHelper:
         self.skip_count_tracking = config.skip_count_tracking
         self.web_session = web_session
         self.num_devices = len(config.devices)
+        self.api_server = config.api_server
 
     # Not used anymore, maybe it can stay here a little longer
     @AsyncLRU(maxsize=10)
@@ -130,7 +131,7 @@ class ApiHelper:
             "service": constants.SponsorBlock_service,
         }
         headers = {"Accept": "application/json"}
-        url = constants.SponsorBlock_api + "skipSegments/" + vid_id_hashed
+        url = self.api_server + "/api/skipSegments/" + vid_id_hashed
         async with self.web_session.get(
             url, headers=headers, params=params
         ) as response:
@@ -201,7 +202,7 @@ class ApiHelper:
         Lets the contributor know that someone skipped the segment (thanks)"""
         if self.skip_count_tracking:
             for i in uuids:
-                url = constants.SponsorBlock_api + "viewedVideoSponsorTime/"
+                url = self.api_server + "/api/viewedVideoSponsorTime/"
                 params = {"UUID": i}
                 await self.web_session.post(url, params=params)
 

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -36,6 +36,7 @@ REPORT_SKIPPED_SEGMENTS_PROMPT = (
 MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
+ENTER_API_SERVER_PROMPT = "Enter the custom API server URL (leave blank to use default): "
 
 
 def get_yn_input(prompt):
@@ -189,6 +190,10 @@ def main(config, debug: bool) -> None:
 
     choice = get_yn_input(AUTOPLAY_PROMPT)
     config.auto_play = choice != "n"
+
+    api_server = input(ENTER_API_SERVER_PROMPT)
+    if api_server:
+        config.api_server = api_server
 
     print("Config finished")
     config.save()

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -36,7 +36,9 @@ REPORT_SKIPPED_SEGMENTS_PROMPT = (
 MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
-ENTER_API_SERVER_PROMPT = "Enter the custom API server URL (leave blank to use default): "
+ENTER_API_SERVER_PROMPT = (
+    "Enter the custom API server URL (leave blank to use default): "
+)
 
 
 def get_yn_input(prompt):

--- a/src/iSponsorBlockTV/constants.py
+++ b/src/iSponsorBlockTV/constants.py
@@ -2,7 +2,6 @@ userAgent = "iSponsorBlockTV/0.1"
 SponsorBlock_service = "youtube"
 SponsorBlock_actiontype = "skip"
 
-SponsorBlock_api = "https://sponsor.ajay.app/api/"
 Youtube_api = "https://www.googleapis.com/youtube/v3/"
 
 skip_categories = (
@@ -19,6 +18,5 @@ skip_categories = (
 )
 
 youtube_client_blacklist = ["TVHTML5_FOR_KIDS"]
-
 
 config_file_blacklist_keys = ["config_file", "data_dir"]

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -42,6 +42,7 @@ class Config:
         self.mute_ads = False
         self.skip_ads = False
         self.auto_play = True
+        self.api_server = "https://sponsor.ajay.app"
         self.__load()
 
     def validate(self):

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -876,6 +876,31 @@ class AutoPlayManager(Vertical):
         self.config.auto_play = event.checkbox.value
 
 
+class ApiServerManager(Vertical):
+    """Manager for the custom API server URL."""
+
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("Custom API Server", classes="title")
+        yield Label(
+            "You can specify a custom SponsorBlock API server URL here.",
+            classes="subtitle",
+        )
+        with Grid(id="api-server-grid"):
+            yield Input(
+                placeholder="Custom API Server URL",
+                id="api-server-input",
+                value=self.config.api_server,
+            )
+
+    @on(Input.Changed, "#api-server-input")
+    def changed_api_server(self, event: Input.Changed):
+        self.config.api_server = event.input.value
+
+
 class ISponsorBlockTVSetupMainScreen(Screen):
     """Making this a separate screen to avoid a bug: https://github.com/Textualize/textual/issues/3221"""
 
@@ -914,6 +939,9 @@ class ISponsorBlockTVSetupMainScreen(Screen):
             )
             yield AutoPlayManager(
                 config=self.config, id="autoplay-manager", classes="container"
+            )
+            yield ApiServerManager(
+                config=self.config, id="api-server-manager", classes="container"
             )
 
     def on_mount(self) -> None:


### PR DESCRIPTION
Fixes #193

Add the ability to specify a custom SponsorBlock API server. (draft implementation by copilot-workspace)

* Add a new configuration option `api_server` in `config.json.template` to specify the custom API server URL.
* Remove the hardcoded `SponsorBlock_api` URL from `src/iSponsorBlockTV/constants.py`.
* Update the `ApiHelper` class in `src/iSponsorBlockTV/api_helpers.py` to use the `api_server` configuration option for API calls.
* Add an option to input a custom API server URL in the CLI setup in `src/iSponsorBlockTV/config_setup.py`.
* Add an option to input a custom API server URL in the graphical setup wizard in `src/iSponsorBlockTV/setup_wizard.py`.
* Set the default `api_server` to "https://sponsor.ajay.app" in `src/iSponsorBlockTV/helpers.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dmunozv04/iSponsorBlockTV/issues/193?shareId=906e7ff3-a473-4f1b-934f-41f84c3159e4).