### PR TITLE
Add setting tp skip post-video ads by force

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -13,6 +13,7 @@
     "mute_ads": true,
     "skip_ads": true,
     "auto_play": true,
+    "force_end": false,
     "apikey": "",
     "channel_whitelist": [
         {"id": "",

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -42,6 +42,7 @@ class Config:
         self.mute_ads = False
         self.skip_ads = False
         self.auto_play = True
+        self.force_end = False
         self.__load()
 
     def validate(self):

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -881,6 +881,34 @@ class AutoPlayManager(Vertical):
     def changed_skip(self, event: Checkbox.Changed):
         self.config.auto_play = event.checkbox.value
 
+class ForceEndManager(Vertical):
+    """Manager for force_end, forcefully ends every video skiping post-video ads."""
+
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("Force video end", classes="title")
+        yield Label(
+            (
+                "If enabled, every video will be forcefully stopped once it has fully",
+                " played through. This skips any post-video ads that might play and"
+                " returns you to the YoutTube home screen."
+            ),
+            classes="subtitle",
+            id="force-end-subtitle",
+        )
+        with Horizontal(id="force-end-container"):
+            yield Checkbox(
+                value=self.config.force_end,
+                id="force-end-switch",
+                label="Enable force end",
+            )
+
+    @on(Checkbox.Changed, "#force-end-switch")
+    def changed_skip(self, event: Checkbox.Changed):
+        self.config.force_end = event.checkbox.value
 
 class ISponsorBlockTVSetupMainScreen(Screen):
     """Making this a separate screen to avoid a bug: https://github.com/Textualize/textual/issues/3221"""
@@ -920,6 +948,9 @@ class ISponsorBlockTVSetupMainScreen(Screen):
             )
             yield AutoPlayManager(
                 config=self.config, id="autoplay-manager", classes="container"
+            )
+            yield ForceEndManager(
+                config=self.config, id="force-end-manager", classes="container"
             )
 
     def on_mount(self) -> None:


### PR DESCRIPTION
When a video is done YouTube sometimes plays +/- 30 seconds of ads after the video. This PR forcefully stops the video when its play time is over, returning to the app home screen and skipping the ads.