### PR TITLE
Add support for different playback speeds

### DIFF
--- a/src/iSponsorBlockTV/main.py
+++ b/src/iSponsorBlockTV/main.py
@@ -103,8 +103,7 @@ class DeviceListener:
             segment_start = segment["start"]
             segment_end = segment["end"]
             is_within_start_range = (
-                position < 1 < segment_end
-                and segment_start <= position < segment_end
+                position < 1 < segment_end and segment_start <= position < segment_end
             )
             is_beyond_current_position = segment_start > position
 

--- a/src/iSponsorBlockTV/main.py
+++ b/src/iSponsorBlockTV/main.py
@@ -101,10 +101,10 @@ class DeviceListener:
         next_segment = None
         for segment in segments:
             segment_start = segment["start"]
+            segment_end = segment["end"]
             is_within_start_range = (
-                position < 1
-                and segment_start <= position < segment["end"]
-                and segment["end"] > 1
+                position < 1 < segment_end
+                and segment_start <= position < segment_end
             )
             is_beyond_current_position = segment_start > position
 

--- a/src/iSponsorBlockTV/main.py
+++ b/src/iSponsorBlockTV/main.py
@@ -101,12 +101,18 @@ class DeviceListener:
         next_segment = None
         for segment in segments:
             segment_start = segment["start"]
-            is_within_start_range = position < 1 and segment_start <= position < segment["end"] and segment["end"] > 1
+            is_within_start_range = (
+                position < 1
+                and segment_start <= position < segment["end"]
+                and segment["end"] > 1
+            )
             is_beyond_current_position = segment_start > position
 
             if is_within_start_range or is_beyond_current_position:
                 next_segment = segment
-                start_next_segment = position if is_within_start_range else segment_start
+                start_next_segment = (
+                    position if is_within_start_range else segment_start
+                )
                 break
         if start_next_segment:
             time_to_next = (

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -155,7 +155,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                     self.shorts_disconnected = True
         elif event_type == "onAutoplayModeChanged":
             create_task(self.set_auto_play_mode(self.auto_play))
-            
+
         elif event_type == "onPlaybackSpeedChanged":
             data = args[0]
             self.playback_speed = float(data.get("playbackSpeed", "1"))
@@ -191,7 +191,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
 
     async def play_video(self, video_id: str) -> bool:
         return await self._command("setPlaylist", {"videoId": video_id})
-    
+
     async def get_now_playing(self):
         return await super()._command("getNowPlaying")
 

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -25,6 +25,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         self.auth.lounge_id_token = None
         self.api_helper = api_helper
         self.volume_state = {}
+        self.playback_speed = 1.0
         self.subscribe_task = None
         self.subscribe_task_watchdog = None
         self.callback = None
@@ -154,6 +155,11 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                     self.shorts_disconnected = True
         elif event_type == "onAutoplayModeChanged":
             create_task(self.set_auto_play_mode(self.auto_play))
+            
+        elif event_type == "onPlaybackSpeedChanged":
+            data = args[0]
+            self.playback_speed = float(data.get("playbackSpeed", "1"))
+            create_task(self.get_now_playing())
 
         super()._process_event(event_type, args)
 
@@ -185,6 +191,9 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
 
     async def play_video(self, video_id: str) -> bool:
         return await self._command("setPlaylist", {"videoId": video_id})
+    
+    async def get_now_playing(self):
+        return await super()._command("getNowPlaying")
 
     # Test to wrap the command function in a mutex to avoid race conditions with
     # the _command_offset (TODO: move to upstream if it works)

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -60,6 +60,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         return self.subscribe_task
 
     # Process a lounge subscription event
+    # skipcq: PY-R1000
     def _process_event(self, event_type: str, args: List[Any]):
         self.logger.debug(f"process_event({event_type}, {args})")
         # (Re)start the watchdog


### PR DESCRIPTION
Handles different playing speeds on skip logic, and improves skip logic to prevent loops on segments at the start of the video. Needs https://github.com/FabioGNR/pyytlounge/pull/17 to be released to work


(Fixes #268 and fixes #119 and fixes #119 )
