### PR TITLE
remove set_auto_play_mode

### DIFF
--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -192,11 +192,6 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 {"volume": self.volume_state.get("volume", 100), "muted": mute_str},
             )
 
-    async def set_auto_play_mode(self, enabled: bool):
-        await super()._command(
-            "setAutoplayMode", {"autoplayMode": "ENABLED" if enabled else "DISABLED"}
-        )
-
     async def play_video(self, video_id: str) -> bool:
         return await self._command("setPlaylist", {"videoId": video_id})
 


### PR DESCRIPTION
Per #274, this removes the `set_auto_play_mode` function from this package, and uses the inherited function of the same name and purpose from the upstream pyytlounge package.