### PR TITLE
Add support for minimum skip length

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -12,7 +12,7 @@
     "skip_count_tracking": true,
     "mute_ads": true,
     "skip_ads": true,
-    "minimum_skip_length": 1,
+    "minimum_skip_length": 0,
     "auto_play": true,
     "join_name": "iSponsorBlockTV",
     "apikey": "",

--- a/config.json.template
+++ b/config.json.template
@@ -12,6 +12,7 @@
     "skip_count_tracking": true,
     "mute_ads": true,
     "skip_ads": true,
+    "minimum_skip_length": 1,
     "auto_play": true,
     "join_name": "iSponsorBlockTV",
     "apikey": "",

--- a/config.json.template
+++ b/config.json.template
@@ -12,7 +12,7 @@
     "skip_count_tracking": true,
     "mute_ads": true,
     "skip_ads": true,
-    "minimum_skip_length": 0,
+    "minimum_skip_length": 1,
     "auto_play": true,
     "join_name": "iSponsorBlockTV",
     "apikey": "",

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -194,7 +194,10 @@ class ApiHelper:
                     segment_dict["UUID"].extend(segment_before_UUID)
                     segments.pop()
                 # Only add segments greater than minimum skip length
-                if segment_dict["end"]-segment_dict["start"] > minimum_skip_length:
+                if (
+                    segment_dict["end"] - segment_dict["start"]
+                    > minimum_skip_length
+                ):
                     segments.append(segment_dict)
         except BaseException:
             pass

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -148,10 +148,10 @@ class ApiHelper:
             if str(i["videoID"]) == str(vid_id):
                 response_json = i
                 break
-        return self.process_segments(self, response_json)
+        return self.process_segments(response_json, minimum_skip_length)
 
     @staticmethod
-    def process_segments(self, response):
+    def process_segments(response, minimum_skip_length):
         segments = []
         ignore_ttl = True
         try:
@@ -194,7 +194,7 @@ class ApiHelper:
                     segment_dict["UUID"].extend(segment_before_UUID)
                     segments.pop()
                 # Only add segments greater than minimum skip length
-                if segment_dict["end"]-segment_dict["start"] > self.minimum_skip_length:
+                if segment_dict["end"]-segment_dict["start"] > minimum_skip_length:
                     segments.append(segment_dict)
         except BaseException:
             pass

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -148,7 +148,7 @@ class ApiHelper:
             if str(i["videoID"]) == str(vid_id):
                 response_json = i
                 break
-        return self.process_segments(response_json, minimum_skip_length)
+        return self.process_segments(response_json, self.minimum_skip_length)
 
     @staticmethod
     def process_segments(response, minimum_skip_length):

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -194,10 +194,7 @@ class ApiHelper:
                     segment_dict["UUID"].extend(segment_before_UUID)
                     segments.pop()
                 # Only add segments greater than minimum skip length
-                if (
-                    segment_dict["end"] - segment_dict["start"]
-                    > minimum_skip_length
-                ):
+                if segment_dict["end"] - segment_dict["start"] > minimum_skip_length:
                     segments.append(segment_dict)
         except BaseException:
             pass

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -29,9 +29,7 @@ SEARCH_CHANNEL_PROMPT = 'Enter a channel name or "/exit" to exit: '
 SELECT_CHANNEL_PROMPT = "Select one option of the above [0-6]: "
 ENTER_CHANNEL_ID_PROMPT = "Enter a channel ID: "
 ENTER_CUSTOM_CHANNEL_NAME_PROMPT = "Enter the channel name: "
-MINIMUM_SKIP_PROMPT = (
-    "Do you want to specify a minimum length of segment to skip? (y/N)"
-)
+MINIMUM_SKIP_PROMPT = "Do you want to specify a minimum length of segment to skip? (y/N)"
 MINIMUM_SKIP_SPECIFICATION_PROMPT = (
     "Enter minimum length of segment to skip in seconds (enter 0 to disable):"
 )

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -185,17 +185,21 @@ def main(config, debug: bool) -> None:
     # Ask for minimum skip length. Confirm input is an integer
     while True:
         try:
-            minimum_skip_length = int(input('Enter minimum length of segment to skip in seconds: '))
+            minimum_skip_length = int(
+                input("Enter minimum length of segment to skip in seconds: ")
+            )
             break
         except ValueError:
-            print('You entered a non integer value, try again.')
+            print("You entered a non integer value, try again.")
             continue
     config.minimum_skip_length = minimum_skip_length
 
     # Ask for minimum skip length. Confirm input is an integer
     while True:
         try:
-            minimum_skip_length = int(input('Enter minimum length of segment to skip in seconds: '))
+            minimum_skip_length = int(
+                input("Enter minimum length of segment to skip in seconds: ")
+            )
             break
         except ValueError:
             print('You entered a non integer value, try again.')

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -182,6 +182,26 @@ def main(config, debug: bool) -> None:
 
     config.channel_whitelist = channel_whitelist
 
+    # Ask for minimum skip length. Confirm input is an integer
+    while True:
+        try:
+            minimum_skip_length = int(input('Enter minimum length of segment to skip in seconds: '))
+            break
+        except ValueError:
+            print('You entered a non integer value, try again.')
+            continue
+    config.minimum_skip_length = minimum_skip_length
+
+    # Ask for minimum skip length. Confirm input is an integer
+    while True:
+        try:
+            minimum_skip_length = int(input('Enter minimum length of segment to skip in seconds: '))
+            break
+        except ValueError:
+            print('You entered a non integer value, try again.')
+            continue
+    config.minimum_skip_length = minimum_skip_length
+
     choice = get_yn_input(REPORT_SKIPPED_SEGMENTS_PROMPT)
     config.skip_count_tracking = choice != "n"
 

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -29,8 +29,12 @@ SEARCH_CHANNEL_PROMPT = 'Enter a channel name or "/exit" to exit: '
 SELECT_CHANNEL_PROMPT = "Select one option of the above [0-6]: "
 ENTER_CHANNEL_ID_PROMPT = "Enter a channel ID: "
 ENTER_CUSTOM_CHANNEL_NAME_PROMPT = "Enter the channel name: "
-MINIMUM_SKIP_PROMPT = "Do you want to specify a minimum length of segment to skip? (y/N)"
-MINIMUM_SKIP_SPECIFICATION_PROMPT = "Enter minimum length of segment to skip in seconds (enter 0 to disable):" 
+MINIMUM_SKIP_PROMPT = (
+    "Do you want to specify a minimum length of segment to skip? (y/N)"
+)
+MINIMUM_SKIP_SPECIFICATION_PROMPT = (
+    "Enter minimum length of segment to skip in seconds (enter 0 to disable):"
+)
 REPORT_SKIPPED_SEGMENTS_PROMPT = (
     "Do you want to report skipped segments to sponsorblock. Only the segment"
     " UUID will be sent? (Y/n) "
@@ -186,19 +190,17 @@ def main(config, debug: bool) -> None:
 
     # Ask for minimum skip length. Confirm input is an integer
     minimum_skip_length = config.minimum_skip_length
-    
+
     choice = get_yn_input(MINIMUM_SKIP_PROMPT)
     if choice == "y":
         while True:
             try:
-                minimum_skip_length = int(
-                    input(MINIMUM_SKIP_SPECIFICATION_PROMPT)
-                )
+                minimum_skip_length = int(input(MINIMUM_SKIP_SPECIFICATION_PROMPT))
                 break
             except ValueError:
                 print("You entered a non integer value, try again.")
                 continue
-    
+
     config.minimum_skip_length = minimum_skip_length
 
     # Ask for minimum skip length. Confirm input is an integer

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -29,6 +29,8 @@ SEARCH_CHANNEL_PROMPT = 'Enter a channel name or "/exit" to exit: '
 SELECT_CHANNEL_PROMPT = "Select one option of the above [0-6]: "
 ENTER_CHANNEL_ID_PROMPT = "Enter a channel ID: "
 ENTER_CUSTOM_CHANNEL_NAME_PROMPT = "Enter the channel name: "
+MINIMUM_SKIP_PROMPT = "Do you want to specify a minimum length of segment to skip? (y/N)"
+MINIMUM_SKIP_SPECIFICATION_PROMPT = "Enter minimum length of segment to skip in seconds (enter 0 to disable):" 
 REPORT_SKIPPED_SEGMENTS_PROMPT = (
     "Do you want to report skipped segments to sponsorblock. Only the segment"
     " UUID will be sent? (Y/n) "
@@ -183,15 +185,20 @@ def main(config, debug: bool) -> None:
     config.channel_whitelist = channel_whitelist
 
     # Ask for minimum skip length. Confirm input is an integer
-    while True:
-        try:
-            minimum_skip_length = int(
-                input("Enter minimum length of segment to skip in seconds: ")
-            )
-            break
-        except ValueError:
-            print("You entered a non integer value, try again.")
-            continue
+    minimum_skip_length = config.minimum_skip_length
+    
+    choice = get_yn_input(MINIMUM_SKIP_PROMPT)
+    if choice == "y":
+        while True:
+            try:
+                minimum_skip_length = int(
+                    input(MINIMUM_SKIP_SPECIFICATION_PROMPT)
+                )
+                break
+            except ValueError:
+                print("You entered a non integer value, try again.")
+                continue
+    
     config.minimum_skip_length = minimum_skip_length
 
     # Ask for minimum skip length. Confirm input is an integer

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -41,7 +41,7 @@ class Config:
         self.skip_count_tracking = True
         self.mute_ads = False
         self.skip_ads = False
-        self.minimum_skip_length = 0
+        self.minimum_skip_length = 1
         self.auto_play = True
         self.join_name = "iSponsorBlockTV"
         self.__load()

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -41,7 +41,7 @@ class Config:
         self.skip_count_tracking = True
         self.mute_ads = False
         self.skip_ads = False
-        self.minimum_skip_length = 1
+        self.minimum_skip_length = 0
         self.auto_play = True
         self.join_name = "iSponsorBlockTV"
         self.__load()

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -41,6 +41,7 @@ class Config:
         self.skip_count_tracking = True
         self.mute_ads = False
         self.skip_ads = False
+        self.minimum_skip_length = 1
         self.auto_play = True
         self.join_name = "iSponsorBlockTV"
         self.__load()

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -723,6 +723,33 @@ class SkipCategoriesManager(Vertical):
         self.config.skip_categories = event.selection_list.selected
 
 
+class MinimumSkipLengthManager(Vertical):
+    """Manager for minimum skip length setting."""
+    
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("Minimum Skip Length", classes="title")
+        yield Label(
+            "Specify the minimum length a segment must meet in order to skip it (in seconds). Default is 1 second; entering 0 will skip all segments.",
+            classes="subtitle",
+        )
+        yield Input(
+            placeholder="Minimum skip length (0 to skip all)",
+            id="minimum-skip-length-input",
+            value=str(getattr(self.config, "minimum_skip_length", 1))
+        )
+
+    @on(Input.Changed, "#minimum-skip-length-input")
+    def changed_minimum_skip_length(self, event: Input.Changed):
+        try:
+            self.config.minimum_skip_length = int(event.input.value)
+        except ValueError:
+            self.config.minimum_skip_length = 1
+
+
 class SkipCountTrackingManager(Vertical):
     """Manager for skip count tracking, allows to enable/disable skip count tracking."""
 

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -935,6 +935,9 @@ class ISponsorBlockTVSetupMainScreen(Screen):
             yield SkipCategoriesManager(
                 config=self.config, id="skip-categories-manager", classes="container"
             )
+            yield MinimumSkipLengthManager(
+                config=self.config, id="minimum-skip-length-manager", classes="container"
+            )
             yield SkipCountTrackingManager(
                 config=self.config, id="count-segments-manager", classes="container"
             )

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -743,9 +743,9 @@ class MinimumSkipLengthManager(Vertical):
             validators=[
                 Function(
                     lambda user_input: user_input.isdigit(),
-                    "Please enter a valid non-negative number"
+                    "Please enter a valid non-negative number",
                 )
-            ]
+            ],
         )
 
     @on(Input.Changed, "#minimum-skip-length-input")

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -739,7 +739,13 @@ class MinimumSkipLengthManager(Vertical):
         yield Input(
             placeholder="Minimum skip length (0 to skip all)",
             id="minimum-skip-length-input",
-            value=str(getattr(self.config, "minimum_skip_length", 1))
+            value=str(getattr(self.config, "minimum_skip_length", 1)),
+            validators=[
+                Function(
+                    lambda user_input: user_input.isdigit(),
+                    "Please enter a valid non-negative number"
+                )
+            ]
         )
 
     @on(Input.Changed, "#minimum-skip-length-input")


### PR DESCRIPTION
This fixes #145, and finishes #169, to fully add support for specifying a minimum segment skip length during setup.  This utilizes @bourkemcrobbo's base to add the specified value to the config and utilize when determining which segments to skip, and additionally adds an input area in the setup TUI for the user to input this value.  As discussed [here](https://github.com/dmunozv04/iSponsorBlockTV/pull/169#discussion_r1655364754), the minimum value is set to 1 in both the CLI and TUI.