### PR TITLE
Textual web UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ rich==14.0.0
 ssdp==1.3.0
 textual==2.1.2
 textual-slider==0.2.0
+textual-serve==1.1.2
 xmltodict==0.14.2
 rich_click==1.8.8

--- a/src/main_web.py
+++ b/src/main_web.py
@@ -1,0 +1,14 @@
+import os
+from textual_serve.server import Server
+
+command    = "python3 main_tui.py"
+host       = os.environ.get("WEB_HOST", "127.0.0.1")
+port       = int(os.environ.get("WEB_PORT", 8000))
+public_url = os.environ.get("WEB_URL")  # e.g. "https://myapp.example.com"
+
+server_kwargs = {"host": host, "port": port}
+if public_url:
+    server_kwargs["public_url"] = public_url
+
+server = Server(command, **server_kwargs)
+server.serve(debug=False) # generates a textual.log debug file when True


### PR DESCRIPTION
Proposing a way to close #74.  Textual now offers the textual-serve library, which allows for self-hosting the web UI with no public server dependency.  

This MR contains the entrypoint for the web server, which defaults to only accepting traffic from localhost and serves at 127.0.0.1:8000.  You can override this behavior and make it available from anywhere on your network by setting:
```
export WEB_HOST=0.0.0.0
export WEB_URL="http://10.1.2.3:8000" # replace with desired IP
```

I'm looking for feedback on how you want to tie this into both the packaging and user onboarding processes.  For now, you can clone the branch and serve the web ui using `python3 main_web.py`.