### PR TITLE
Added proxy support

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -20,5 +20,6 @@
         {"id": "",
         "name": ""
         }
-    ]
+    ],
+    "use_proxy": true
 }

--- a/config.json.template
+++ b/config.json.template
@@ -21,5 +21,5 @@
         "name": ""
         }
     ],
-    "use_proxy": true
+    "use_proxy": false
 }

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -5,7 +5,7 @@ import aiohttp
 from . import api_helpers, ytlounge
 
 # Constants for user input prompts
-USE_PROXY_PROMPT = "Do you want to use system-wide proxy?"
+USE_PROXY_PROMPT = "Do you want to use system-wide proxy? (y/N)"
 ATVS_REMOVAL_PROMPT = (
     "Do you want to remove the legacy 'atvs' entry (the app won't start with it present)? (y/N) "
 )

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -5,6 +5,7 @@ import aiohttp
 from . import api_helpers, ytlounge
 
 # Constants for user input prompts
+USE_PROXY_PROMPT = "Do you want to use system-wide proxy?"
 ATVS_REMOVAL_PROMPT = (
     "Do you want to remove the legacy 'atvs' entry (the app won't start with it present)? (y/N) "
 )
@@ -75,6 +76,10 @@ async def pair_device(web_session: aiohttp.ClientSession):
 
 def main(config, debug: bool) -> None:
     print("Welcome to the iSponsorBlockTV cli setup wizard")
+
+    choice = get_yn_input(USE_PROXY_PROMPT)
+    config.use_proxy = choice == "y"
+
     loop = asyncio.get_event_loop_policy().get_event_loop()
     web_session = loop.run_until_complete(create_web_session(config.use_proxy))
     if debug:

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -46,7 +46,7 @@ def get_yn_input(prompt):
 
 
 async def create_web_session():
-    return aiohttp.ClientSession()
+    return aiohttp.ClientSession(trust_env=True)
 
 
 async def pair_device(web_session: aiohttp.ClientSession):

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -45,8 +45,8 @@ def get_yn_input(prompt):
     return None
 
 
-async def create_web_session():
-    return aiohttp.ClientSession(trust_env=True)
+async def create_web_session(use_proxy):
+    return aiohttp.ClientSession(trust_env = use_proxy)
 
 
 async def pair_device(web_session: aiohttp.ClientSession):
@@ -76,7 +76,7 @@ async def pair_device(web_session: aiohttp.ClientSession):
 def main(config, debug: bool) -> None:
     print("Welcome to the iSponsorBlockTV cli setup wizard")
     loop = asyncio.get_event_loop_policy().get_event_loop()
-    web_session = loop.run_until_complete(create_web_session())
+    web_session = loop.run_until_complete(create_web_session(config.use_proxy))
     if debug:
         loop.set_debug(True)
     asyncio.set_event_loop(loop)

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -44,6 +44,7 @@ class Config:
         self.minimum_skip_length = 1
         self.auto_play = True
         self.join_name = "iSponsorBlockTV"
+        self.use_proxy = False
         self.__load()
 
     def validate(self):

--- a/src/iSponsorBlockTV/main.py
+++ b/src/iSponsorBlockTV/main.py
@@ -172,9 +172,9 @@ async def main_async(config, debug, http_tracing):
         trace_config.on_response_chunk_received.append(tracer.on_response_chunk_received)
         trace_config.on_request_end.append(tracer.on_request_end)
         trace_config.on_request_exception.append(tracer.on_request_exception)
-        web_session = aiohttp.ClientSession(trust_env=True, connector=tcp_connector, trace_configs=[trace_config])
+        web_session = aiohttp.ClientSession(trust_env=config.use_proxy, connector=tcp_connector, trace_configs=[trace_config])
     else:
-        web_session = aiohttp.ClientSession(trust_env=True, connector=tcp_connector)
+        web_session = aiohttp.ClientSession(trust_env=config.use_proxy, connector=tcp_connector)
 
     api_helper = api_helpers.ApiHelper(config, web_session)
     for i in config.devices:

--- a/src/iSponsorBlockTV/main.py
+++ b/src/iSponsorBlockTV/main.py
@@ -172,9 +172,9 @@ async def main_async(config, debug, http_tracing):
         trace_config.on_response_chunk_received.append(tracer.on_response_chunk_received)
         trace_config.on_request_end.append(tracer.on_request_end)
         trace_config.on_request_exception.append(tracer.on_request_exception)
-        web_session = aiohttp.ClientSession(connector=tcp_connector, trace_configs=[trace_config])
+        web_session = aiohttp.ClientSession(trust_env=True, connector=tcp_connector, trace_configs=[trace_config])
     else:
-        web_session = aiohttp.ClientSession(connector=tcp_connector)
+        web_session = aiohttp.ClientSession(trust_env=True, connector=tcp_connector)
 
     api_helper = api_helpers.ApiHelper(config, web_session)
     for i in config.devices:

--- a/src/iSponsorBlockTV/setup-wizard-style.tcss
+++ b/src/iSponsorBlockTV/setup-wizard-style.tcss
@@ -383,3 +383,9 @@ MigrationScreen {
     padding: 1;
     height: auto;
 }
+
+/* Use Proxy */
+#useproxy-container{
+    padding: 1;
+    height: auto;
+}

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -903,7 +903,7 @@ class UseProxyManager(Vertical):
             "This feature allows application to use system proxy,"
             " if it is set in environment variables."
             " This parameter will be passed in all [i]aiohttp.ClientSession[/i]"
-            " calls. For further information, see \"[i]trust_env[/i]\" section at"
+            ' calls. For further information, see "[i]trust_env[/i]" section at'
             " [link='https://docs.aiohttp.org/en/stable/client_reference.html']"
             "aiohttp documentation[/link].",
             classes="subtitle",

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -889,6 +889,30 @@ class AutoPlayManager(Vertical):
     def changed_skip(self, event: Checkbox.Changed):
         self.config.auto_play = event.checkbox.value
 
+class UseProxyManager(Vertical):
+    """Manager for proxy use, allows enabling/disabling use of proxy."""
+
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("Use proxy", classes="title")
+        yield Label(
+            "This feature allows application to use system proxy, if it is set in environmental variables.",
+            classes="subtitle",
+            id="useproxy-subtitle",
+        )
+        with Horizontal(id="useproxy-container"):
+            yield Checkbox(
+                value=self.config.use_proxy,
+                id="useproxy-switch",
+                label="Use proxy",
+            )
+
+    @on(Checkbox.Changed, "#useproxy-switch")
+    def changed_skip(self, event: Checkbox.Changed):
+        self.config.use_proxy = event.checkbox.value
 
 class ISponsorBlockTVSetupMainScreen(Screen):
     TITLE = "iSponsorBlockTV"
@@ -926,6 +950,7 @@ class ISponsorBlockTVSetupMainScreen(Screen):
             )
             yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
             yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
+            yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
 
     def on_mount(self) -> None:
         if self.check_for_old_config_entries():

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -233,7 +233,7 @@ class AddDevice(ModalWithClickExit):
     def __init__(self, config, **kwargs) -> None:
         super().__init__(**kwargs)
         self.config = config
-        self.web_session = aiohttp.ClientSession(trust_env=True)
+        self.web_session = aiohttp.ClientSession(trust_env=config.use_proxy)
         self.api_helper = api_helpers.ApiHelper(config, self.web_session)
         self.devices_discovered_dial = []
 
@@ -382,7 +382,7 @@ class AddChannel(ModalWithClickExit):
     def __init__(self, config, **kwargs) -> None:
         super().__init__(**kwargs)
         self.config = config
-        web_session = aiohttp.ClientSession(trust_env=True)
+        web_session = aiohttp.ClientSession(trust_env=config.use_proxy)
         self.api_helper = api_helpers.ApiHelper(config, web_session)
 
     def compose(self) -> ComposeResult:

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -899,7 +899,8 @@ class UseProxyManager(Vertical):
     def compose(self) -> ComposeResult:
         yield Label("Use proxy", classes="title")
         yield Label(
-            "This feature allows application to use system proxy, if it is set in environmental variables.",
+            "This feature allows application to use system proxy,"
+            " if it is set in environmental variables.",
             classes="subtitle",
             id="useproxy-subtitle",
         )

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -949,8 +949,8 @@ class ISponsorBlockTVSetupMainScreen(Screen):
                 config=self.config, id="channel-whitelist-manager", classes="container"
             )
             yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
-            yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
             yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
+            yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
 
     def on_mount(self) -> None:
         if self.check_for_old_config_entries():

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -233,7 +233,7 @@ class AddDevice(ModalWithClickExit):
     def __init__(self, config, **kwargs) -> None:
         super().__init__(**kwargs)
         self.config = config
-        self.web_session = aiohttp.ClientSession()
+        self.web_session = aiohttp.ClientSession(trust_env=True)
         self.api_helper = api_helpers.ApiHelper(config, self.web_session)
         self.devices_discovered_dial = []
 
@@ -382,7 +382,7 @@ class AddChannel(ModalWithClickExit):
     def __init__(self, config, **kwargs) -> None:
         super().__init__(**kwargs)
         self.config = config
-        web_session = aiohttp.ClientSession()
+        web_session = aiohttp.ClientSession(trust_env=True)
         self.api_helper = api_helpers.ApiHelper(config, web_session)
 
     def compose(self) -> ComposeResult:

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -901,7 +901,11 @@ class UseProxyManager(Vertical):
         yield Label("Use proxy", classes="title")
         yield Label(
             "This feature allows application to use system proxy,"
-            " if it is set in environmental variables.",
+            " if it is set in environment variables."
+            " This parameter will be passed in all [i]aiohttp.ClientSession[/i]"
+            " calls. For further information, see \"[i]trust_env[/i]\" section at"
+            " [link='https://docs.aiohttp.org/en/stable/client_reference.html']"
+            "aiohttp documentation[/link].",
             classes="subtitle",
             id="useproxy-subtitle",
         )

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -948,9 +948,9 @@ class ISponsorBlockTVSetupMainScreen(Screen):
             yield ChannelWhitelistManager(
                 config=self.config, id="channel-whitelist-manager", classes="container"
             )
-            yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
-            yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
+            yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")            
             yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
+            yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
 
     def on_mount(self) -> None:
         if self.check_for_old_config_entries():


### PR DESCRIPTION
Hello!

Added parameter `use_proxy` to configuration file, which is passed into all calls of `aiohttp.ClientSession` with `trust_env=config.use_proxy`.

Tested on linux host with xray client. With `http_proxy` and `https_proxy` environment variables set it works just great.

I think this PR closes this issue https://github.com/dmunozv04/iSponsorBlockTV/issues/330