### PR TITLE
Respect empty skip categories instead of forcing sponsor default

### DIFF
--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -112,7 +112,7 @@ class ApiHelper:
     @AsyncConditionalTTL(time_to_live=300, maxsize=10)  # 5 minutes for non-locked segments
     async def get_segments(self, vid_id):
         if not self.skip_categories:
-            return [], True  # Categories explicitly empty, skip segment fetching
+            return ([], True)  # Categories explicitly empty, skip segment fetching
         if await self.is_whitelisted(vid_id):
             return (
                 [],

--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -111,6 +111,8 @@ class ApiHelper:
     @list_to_tuple  # Convert list to tuple so it can be used as a key in the cache
     @AsyncConditionalTTL(time_to_live=300, maxsize=10)  # 5 minutes for non-locked segments
     async def get_segments(self, vid_id):
+        if not self.skip_categories:
+            return [], True  # Categories explicitly empty, skip segment fetching
         if await self.is_whitelisted(vid_id):
             return (
                 [],

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -120,7 +120,7 @@ def main(config, debug: bool) -> None:
     config.apikey = apikey
 
     skip_categories = config.skip_categories
-    if skip_categories:
+    if skip_categories is not None:
         choice = get_yn_input(CHANGE_SKIP_CATEGORIES_PROMPT)
         if choice == "y":
             categories = input(ENTER_SKIP_CATEGORIES_PROMPT)

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -36,7 +36,7 @@ class Config:
 
         self.devices = []
         self.apikey = ""
-        self.skip_categories = []  # These are the categories on the config file
+        self.skip_categories = None  # None = absent from config; [] = explicitly empty
         self.channel_whitelist = []
         self.skip_count_tracking = True
         self.mute_ads = False
@@ -68,7 +68,7 @@ class Config:
         self.devices = [Device(i) for i in self.devices]
         if not self.apikey and self.channel_whitelist:
             raise ValueError("No youtube API key found and channel whitelist is not empty")
-        if not self.skip_categories:
+        if self.skip_categories is None:
             self.skip_categories = ["sponsor"]
             print("No categories found, using default: sponsor")
 

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -691,9 +691,10 @@ class SkipCategoriesManager(Vertical):
         yield Label("Skip Categories", classes="title")
         yield Label("Select the categories you want to skip", classes="subtitle")
         skip_categories_parsed = []
+        configured = self.config.skip_categories or []
         for i in skip_categories:
             name, value = i
-            if value in self.config.skip_categories:
+            if value in configured:
                 skip_categories_parsed.append((name, value, True))
             else:
                 skip_categories_parsed.append((name, value, False))


### PR DESCRIPTION
When a user deselects all skip categories (to only skip YouTube ads, not in-video SponsorBlock segments), the config validator was overriding the empty list with `["sponsor"]`. This meant there was no way to disable SponsorBlock segment skipping while keeping YouTube ad skipping enabled.

## Root cause

Two issues combine to cause this bug:

1. `Config.validate()` replaces any falsy `skip_categories` with `["sponsor"]`, so an intentionally empty list gets overridden.
2. Even if the override were removed, omitting the `category` parameter from the SponsorBlock API causes it to default to `"sponsor"` — so an empty list still results in sponsor segments being fetched and skipped.

## Changes

- **helpers.py**: Use `None` sentinel as the default instead of `[]`. `None` means "key absent from config" (backward-compatible default to `["sponsor"]`), while `[]` means "user explicitly deselected all categories."
- **api_helpers.py**: Add early return in `get_segments()` when `skip_categories` is empty, preventing unnecessary API calls that would return sponsor segments due to the API's default behavior.
- **config_setup.py**: Change `if skip_categories:` to `if skip_categories is not None:` so the CLI setup wizard can distinguish between "not configured" and "intentionally empty."
- **setup_wizard.py**: Guard against `None` value in the category selection list to prevent TypeError.

## What this does NOT fix

The `list_to_tuple` decorator wrapping `get_segments` is not `await`-aware (pre-existing). This diff does not change that behavior.

Fixes #407.