### PR TITLE
Remove poi_highlight from configurators

### DIFF
--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -17,7 +17,7 @@ ENTER_API_KEY_PROMPT = "Enter your API key: "
 CHANGE_SKIP_CATEGORIES_PROMPT = "Skip categories already specified. Change them? (y/N) "
 ENTER_SKIP_CATEGORIES_PROMPT = (
     "Enter skip categories (space or comma sepparated) Options: [sponsor,"
-    " selfpromo, exclusive_access, interaction, poi_highlight, intro, outro,"
+    " selfpromo, exclusive_access, interaction, intro, outro,"
     " preview, filler, music_offtopic]:\n"
 )
 WHITELIST_CHANNELS_PROMPT = "Do you want to whitelist any channels from being ad-blocked? (y/N) "

--- a/src/iSponsorBlockTV/constants.py
+++ b/src/iSponsorBlockTV/constants.py
@@ -13,7 +13,6 @@ skip_categories = (
     ("Music Offtopic", "music_offtopic"),
     ("Interaction", "interaction"),
     ("Exclusive Access", "exclusive_access"),
-    ("POI Highlight", "poi_highlight"),
     ("Preview", "preview"),
     ("Filler", "filler"),
 )


### PR DESCRIPTION
Hi!

This covers issue #319 to remove the “poi_highlight” from constants.py and config_setup.py because it currently does nothing since it’s less than the minimum segment length.