### PR TITLE
Allow changing the SponsorBlock API URL

### DIFF
--- a/src/iSponsorBlockTV/api_helpers.py
+++ b/src/iSponsorBlockTV/api_helpers.py
@@ -61,6 +61,7 @@ class ApiHelper:
         self.web_session = web_session
         self.num_devices = len(config.devices)
         self.minimum_skip_length = config.minimum_skip_length
+        self.sponsorblock_api_url = config.sponsorblock_api_url
 
     @staticmethod
     def _normalize_pairing_code(pairing_code):
@@ -192,7 +193,7 @@ class ApiHelper:
             "service": constants.SponsorBlock_service,
         }
         headers = {"Accept": "application/json"}
-        url = constants.SponsorBlock_api + "skipSegments/" + vid_id_hashed
+        url = self.sponsorblock_api_url + "skipSegments/" + vid_id_hashed
         async with self.web_session.get(url, headers=headers, params=params) as response:
             response_json = await response.json()
         if response.status != 200:
@@ -264,7 +265,7 @@ class ApiHelper:
         Lets the contributor know that someone skipped the segment (thanks)"""
         if self.skip_count_tracking:
             for i in uuids:
-                url = constants.SponsorBlock_api + "viewedVideoSponsorTime/"
+                url = self.sponsorblock_api_url + "viewedVideoSponsorTime/"
                 params = {"UUID": i}
                 await self.web_session.post(url, params=params)
 

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -3,6 +3,7 @@ import asyncio
 import aiohttp
 
 from . import api_helpers
+from .constants import SponsorBlock_api
 
 # Constants for user input prompts
 USE_PROXY_PROMPT = "Do you want to use system-wide proxy? (y/N)"
@@ -36,6 +37,7 @@ REPORT_SKIPPED_SEGMENTS_PROMPT = (
 MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
+ENTER_SPONSORBLOCK_API_PROMPT = f"Enter SponsorBlock API URL (default: {SponsorBlock_api}): "
 
 
 def get_yn_input(prompt):
@@ -205,6 +207,10 @@ def main(config, debug: bool) -> None:
 
     choice = get_yn_input(AUTOPLAY_PROMPT)
     config.auto_play = choice != "n"
+
+    # SponsorBlock API URL
+    api_url = input(ENTER_SPONSORBLOCK_API_PROMPT).strip()
+    config.sponsorblock_api_url = api_url if api_url else SponsorBlock_api
 
     print("Config finished")
     config.save()

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -71,6 +71,7 @@ async def pair_device(config, web_session: aiohttp.ClientSession, api_helper):
         print(f"Failed to pair device: {e}")
         return
 
+
 # skipcq: PY-R1000
 def main(config, debug: bool) -> None:
     print("Welcome to the iSponsorBlockTV cli setup wizard")

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -71,7 +71,7 @@ async def pair_device(config, web_session: aiohttp.ClientSession, api_helper):
         print(f"Failed to pair device: {e}")
         return
 
-
+# skipcq: PY-R1000
 def main(config, debug: bool) -> None:
     print("Welcome to the iSponsorBlockTV cli setup wizard")
 

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -8,7 +8,7 @@ import rich_click as click
 from appdirs import user_data_dir
 
 from . import config_setup, main, setup_wizard
-from .constants import config_file_blacklist_keys, github_wiki_base_url
+from .constants import config_file_blacklist_keys, github_wiki_base_url, SponsorBlock_api
 
 
 class Device:
@@ -54,6 +54,7 @@ class Config:
         self.auto_play = True
         self.join_name = "iSponsorBlockTV"
         self.use_proxy = False
+        self.sponsorblock_api_url = SponsorBlock_api
         self.__load()
 
     def validate(self):

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -36,7 +36,7 @@ from textual_slider import Slider
 
 # Local imports
 from . import api_helpers
-from .constants import skip_categories
+from .constants import skip_categories, SponsorBlock_api
 
 
 def _validate_pairing_code(pairing_code: str) -> bool:
@@ -1069,6 +1069,34 @@ class UseProxyManager(Vertical):
         self.config.use_proxy = event.checkbox.value
 
 
+class SponsorBlockApiUrlManager(Vertical):
+    """Manager for SponsorBlock API URL."""
+
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("SponsorBlock API URL", classes="title")
+        yield Label(
+            (
+                f"The URL for the SponsorBlock API (default: {SponsorBlock_api})."
+            ),
+            classes="subtitle",
+            id="sponsorblock-api-url-subtitle",
+        )
+        yield Input(
+            placeholder="SponsorBlock API URL",
+            id="sponsorblock-api-url-input",
+            value=self.config.sponsorblock_api_url,
+        )
+
+    @on(Input.Changed, "#sponsorblock-api-url-input")
+    def changed_api_url(self, event: Input.Changed):
+        if event.input.value.strip():
+            self.config.sponsorblock_api_url = event.input.value.strip()
+
+
 class ISponsorBlockTVSetup(App):
     TITLE = "iSponsorBlockTV"
     SUB_TITLE = "Setup Wizard"
@@ -1111,6 +1139,9 @@ class ISponsorBlockTVSetup(App):
             yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
             yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
             yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
+            yield SponsorBlockApiUrlManager(
+                config=self.config, id="sponsorblock-api-url-manager", classes="container"
+            )
 
     async def on_mount(self) -> None:
         self.web_session = aiohttp.ClientSession(trust_env=self.config.use_proxy)

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -1079,9 +1079,7 @@ class SponsorBlockApiUrlManager(Vertical):
     def compose(self) -> ComposeResult:
         yield Label("SponsorBlock API URL", classes="title")
         yield Label(
-            (
-                f"The URL for the SponsorBlock API (default: {SponsorBlock_api})."
-            ),
+            (f"The URL for the SponsorBlock API (default: {SponsorBlock_api})."),
             classes="subtitle",
             id="sponsorblock-api-url-subtitle",
         )


### PR DESCRIPTION
This adds a configurable sponsorblock_api_url option that allows users to specify a custom SponsorBlock API endpoint. This is useful for avoiding Cloudflare rate limits by using the Cloudflare-free endpoint at https://api.sponsor.ajay.app/api/

- Add sponsorblock_api_url config option (default: None uses constants)
- Update ApiHelper to use the configurable URL
- Add CLI setup wizard prompt for custom API URL
- Add GUI setup wizard manager for custom API URL

Fixes #469. Working Docker image available at https://github.com/SamyDjemai/iSponsorBlockTV/pkgs/container/isponsorblocktv/912182215?tag=feature-custom-sponsorblock-api-url