### PR TITLE
Add redirect_to_home_on_end config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ The device can also be manually added to iSponsorBlockTV with a YouTube TV code.
 This code can be found in the settings page of your YouTube TV application.
 
 ## Autoplay behavior
+<!-- markdownlint-disable MD013 MD033 -->
 
 iSponsorBlockTV provides two related settings:
 
 - **auto_play**: When enabled, videos autoplay continuously.
 - **redirect_to_home_on_end**: When enabled and auto_play is disabled, redirects to YouTube homepage after video ends.
 
-<!-- markdownlint-disable MD013 MD033 -->
 <details>
 <summary>Configuration combinations:</summary>
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ during setup.
 The device can also be manually added to iSponsorBlockTV with a YouTube TV code.
 This code can be found in the settings page of your YouTube TV application.
 
+## Autoplay behavior
+
+iSponsorBlockTV provides two related settings:
+
+- **auto_play**: When enabled, videos autoplay continuously.
+- **redirect_to_home_on_end**: When enabled and auto_play is disabled, redirects to YouTube homepage after video ends.
+
+<details>
+
+<summary>Configuration combinations:</summary>
+
+- **`auto_play`: True** - Videos autoplay continuously. `redirect_to_home_on_end` has no effect.
+- **`auto_play`: False, `redirect_to_home_on_end`: True** - Video ends redirect to YouTube homepage.
+- **`auto_play`: False, `redirect_to_home_on_end`: False** - Video ends show "Next Video" suggestions (default YouTube behavior).
+
+</details>
+
+> [!NOTE]
+> `redirect_to_home_on_end` only applies when `auto_play` is disabled.
+
 ## Libraries used
 
 - [pyytlounge](https://github.com/FabioGNR/pyytlounge) Used to interact with the

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ iSponsorBlockTV provides two related settings:
 - **auto_play**: When enabled, videos autoplay continuously.
 - **redirect_to_home_on_end**: When enabled and auto_play is disabled, redirects to YouTube homepage after video ends.
 
-<details>
+<!-- markdownlint-disable MD033 -->
 
+<details>
 <summary>Configuration combinations:</summary>
 
 - **`auto_play`: True** - Videos autoplay continuously. `redirect_to_home_on_end` has no effect.
@@ -75,8 +76,9 @@ iSponsorBlockTV provides two related settings:
 
 </details>
 
-> [!NOTE]
-> `redirect_to_home_on_end` only applies when `auto_play` is disabled.
+<!-- markdownlint-enable MD033 -->
+
+> [!NOTE] > `redirect_to_home_on_end` only applies when `auto_play` is disabled.
 
 ## Libraries used
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ iSponsorBlockTV provides two related settings:
 - **auto_play**: When enabled, videos autoplay continuously.
 - **redirect_to_home_on_end**: When enabled and auto_play is disabled, redirects to YouTube homepage after video ends.
 
-<!-- markdownlint-disable MD033 -->
-
+<!-- markdownlint-disable MD013 MD033 -->
 <details>
 <summary>Configuration combinations:</summary>
 
@@ -75,10 +74,10 @@ iSponsorBlockTV provides two related settings:
 - **`auto_play`: False, `redirect_to_home_on_end`: False** - Video ends show "Next Video" suggestions (default YouTube behavior).
 
 </details>
+<!-- markdownlint-enable MD013 MD033 -->
 
-<!-- markdownlint-enable MD033 -->
-
-> [!NOTE] > `redirect_to_home_on_end` only applies when `auto_play` is disabled.
+> [!NOTE]
+> `redirect_to_home_on_end` only applies when `auto_play` is disabled.
 
 ## Libraries used
 

--- a/config.json.template
+++ b/config.json.template
@@ -14,6 +14,7 @@
     "skip_ads": true,
     "minimum_skip_length": 1,
     "auto_play": true,
+    "redirect_to_home_on_end": true,
     "join_name": "iSponsorBlockTV",
     "apikey": "",
     "channel_whitelist": [

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -38,6 +38,7 @@ MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
 ENTER_SPONSORBLOCK_API_PROMPT = f"Enter SponsorBlock API URL (default: {SponsorBlock_api}): "
+REDIRECT_TO_HOME_PROMPT = "When autoplay is off, redirect to YouTube homepage on video end? (Y/n) "
 
 
 def get_yn_input(prompt):
@@ -212,6 +213,13 @@ def main(config, debug: bool) -> None:
     # SponsorBlock API URL
     api_url = input(ENTER_SPONSORBLOCK_API_PROMPT).strip()
     config.sponsorblock_api_url = api_url if api_url else SponsorBlock_api
+
+    if not config.auto_play:
+        choice = get_yn_input(REDIRECT_TO_HOME_PROMPT)
+        config.redirect_to_home_on_end = choice != "n"
+    else:
+        # When autoplay is on, redirect setting doesn't apply
+        config.redirect_to_home_on_end = True  # Default, but unused
 
     print("Config finished")
     config.save()

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -55,6 +55,8 @@ class Config:
         self.join_name = "iSponsorBlockTV"
         self.use_proxy = False
         self.sponsorblock_api_url = SponsorBlock_api
+        # Initialize with default, will be overridden by config if present
+        self.redirect_to_home_on_end = True
         self.__load()
 
     def validate(self):
@@ -114,6 +116,10 @@ class Config:
                     sys.exit()
             else:
                 print("Blank config file created")
+
+        # Ensure redirect_to_home_on_end exists (backward compatibility)
+        if not hasattr(self, "redirect_to_home_on_end"):
+            self.redirect_to_home_on_end = True
 
     def save(self):
         with open(self.config_file, "w", encoding="utf-8") as f:

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -1039,7 +1039,7 @@ class AutoPlayManager(Vertical):
                 value=self.config.redirect_to_home_on_end,
                 id="redirect-to-home-switch",
                 label="Redirect to YouTube homepage when video ends",
-                disabled=not not self.config.auto_play,  # Disabled when autoplay=True
+                disabled=self.config.auto_play,  # Disabled when autoplay=True
             )
             yield redirect_checkbox
             yield Label(

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -1013,7 +1013,7 @@ class ChannelWhitelistManager(Vertical):
 
 
 class AutoPlayManager(Vertical):
-    """Manager for autoplay, allows enabling/disabling autoplay."""
+    """Manager for autoplay and redirect behavior settings."""
 
     def __init__(self, config, **kwargs) -> None:
         super().__init__(**kwargs)
@@ -1022,7 +1022,7 @@ class AutoPlayManager(Vertical):
     def compose(self) -> ComposeResult:
         yield Label("Autoplay", classes="title")
         yield Label(
-            "This feature allows you to enable/disable autoplay",
+            "Control autoplay behavior and video end actions",
             classes="subtitle",
             id="autoplay-subtitle",
         )
@@ -1032,10 +1032,32 @@ class AutoPlayManager(Vertical):
                 id="autoplay-switch",
                 label="Enable autoplay",
             )
+        with Horizontal(id="redirect-container"):
+            # Disable redirect checkbox when autoplay is enabled
+            # (redirect only applies when autoplay is off)
+            redirect_checkbox = Checkbox(
+                value=self.config.redirect_to_home_on_end,
+                id="redirect-to-home-switch",
+                label="Redirect to YouTube homepage when video ends",
+                disabled=not not self.config.auto_play,  # Disabled when autoplay=True
+            )
+            yield redirect_checkbox
+            yield Label(
+                "(Only applies when autoplay is disabled)",
+                classes="hint",
+                id="redirect-hint",
+            )
 
     @on(Checkbox.Changed, "#autoplay-switch")
-    def changed_skip(self, event: Checkbox.Changed):
+    def changed_autoplay(self, event: Checkbox.Changed):
         self.config.auto_play = event.checkbox.value
+        # Update redirect checkbox disabled state
+        self.query_one("#redirect-to-home-switch", Checkbox).disabled = self.config.auto_play
+        self.query_one("#redirect-hint", Label).update("(Only applies when autoplay is disabled)")
+
+    @on(Checkbox.Changed, "#redirect-to-home-switch")
+    def changed_redirect_to_home(self, event: Checkbox.Changed):
+        self.config.redirect_to_home_on_end = event.checkbox.value
 
 
 class UseProxyManager(Vertical):

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -42,6 +42,7 @@ class _CallbackListener(EventListener):
         if not event.enabled and not event.supported:
             self._lounge.logger.warning("Autoplay not supported on this device")
 
+
 class YtLoungeApi(pyytlounge.YtLoungeApi):
     def __init__(
         self,
@@ -77,7 +78,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             self.skip_ads = config.skip_ads
             self.auto_play = config.auto_play
             # Using getattr for backward compatibility with old configs
-            self.redirect_to_home_on_end = getattr(config, 'redirect_to_home_on_end', True)
+            self.redirect_to_home_on_end = getattr(config, "redirect_to_home_on_end", True)
         self._command_mutex = asyncio.Lock()
 
     async def _handle_playback_state_event(self, event: PlaybackStateEvent) -> None:
@@ -245,7 +246,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
 
         elif event_type == "onAutoplayModeChanged":
             # Check if we have the redirect_to_home_on_end attribute
-            redirect_setting = getattr(self, 'redirect_to_home_on_end', True)
+            redirect_setting = getattr(self, "redirect_to_home_on_end", True)
 
             if self.auto_play:
                 # Always enable autoplay (ENABLED mode)

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -7,7 +7,7 @@ import pyytlounge
 from aiohttp import ClientSession
 
 from pyytlounge.event_listener import EventListener
-from pyytlounge.events import NowPlayingEvent, PlaybackStateEvent
+from pyytlounge.events import AutoplayModeChangedEvent, NowPlayingEvent, PlaybackStateEvent
 from pyytlounge.models import State
 from pyytlounge.wrapper import NotLinkedException, api_base, as_aiter, Dict
 from uuid import uuid4
@@ -40,7 +40,7 @@ class _CallbackListener(EventListener):
         # event.enabled: bool - whether autoplay is enabled
         # event.supported: bool - whether autoplay is supported
         if not event.enabled and not event.supported:
-            logger.warning("Autoplay not supported on this device")
+            self._lounge.logger.warning("Autoplay not supported on this device")
 
 class YtLoungeApi(pyytlounge.YtLoungeApi):
     def __init__(
@@ -253,14 +253,13 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             elif redirect_setting:
                 # Disable autoplay with redirect (DISABLED mode)
                 create_task(self.set_auto_play_mode(False))
-            # else: Don't call set_auto_play_mode → preserves YouTube's default behavior
-            #       (shows "Next Video" suggestions without redirecting to home)
             else:
-                # When not calling set_auto_play_mode, log for debugging
+                # Don't call set_auto_play_mode → preserves YouTube's default behavior
+                # (shows "Next Video" suggestions without redirecting to home)
                 self.logger.debug(
                     "Not setting autoplay mode to preserve YouTube default behavior "
                     "(redirect_to_home_on_end=False)"
-              )
+                )
 
         elif event_type == "onPlaybackSpeedChanged":
             data = args[0]

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -36,6 +36,11 @@ class _CallbackListener(EventListener):
     async def now_playing_changed(self, event: NowPlayingEvent) -> None:
         await self._lounge._handle_now_playing_event(event)
 
+    async def autoplay_changed(self, event: AutoplayModeChangedEvent) -> None:
+        # event.enabled: bool - whether autoplay is enabled
+        # event.supported: bool - whether autoplay is supported
+        if not event.enabled and not event.supported:
+            logger.warning("Autoplay not supported on this device")
 
 class YtLoungeApi(pyytlounge.YtLoungeApi):
     def __init__(
@@ -71,7 +76,8 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             self.mute_ads = config.mute_ads
             self.skip_ads = config.skip_ads
             self.auto_play = config.auto_play
-            self.redirect_to_home_on_end = config.redirect_to_home_on_end
+            # Using getattr for backward compatibility with old configs
+            self.redirect_to_home_on_end = getattr(config, 'redirect_to_home_on_end', True)
         self._command_mutex = asyncio.Lock()
 
     async def _handle_playback_state_event(self, event: PlaybackStateEvent) -> None:
@@ -236,14 +242,25 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 data = args[0]
                 if data["reason"] == "disconnectedByUserScreenInitiated":  # Short playing?
                     self.shorts_disconnected = True
+
         elif event_type == "onAutoplayModeChanged":
+            # Check if we have the redirect_to_home_on_end attribute
+            redirect_setting = getattr(self, 'redirect_to_home_on_end', True)
+
             if self.auto_play:
-                # Always enable autoplay when auto_play is True
+                # Always enable autoplay (ENABLED mode)
                 create_task(self.set_auto_play_mode(True))
-            elif self.redirect_to_home_on_end:
-                # Only disable autoplay (causing redirect) when explicitly requested
+            elif redirect_setting:
+                # Disable autoplay with redirect (DISABLED mode)
                 create_task(self.set_auto_play_mode(False))
-            # else: Don't call set_auto_play_mode, letting YouTube use default behavior
+            # else: Don't call set_auto_play_mode → preserves YouTube's default behavior
+            #       (shows "Next Video" suggestions without redirecting to home)
+            else:
+                # When not calling set_auto_play_mode, log for debugging
+                self.logger.debug(
+                    "Not setting autoplay mode to preserve YouTube default behavior "
+                    "(redirect_to_home_on_end=False)"
+              )
 
         elif event_type == "onPlaybackSpeedChanged":
             data = args[0]

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -64,12 +64,14 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         self.logger = logger
         self.shorts_disconnected = False
         self.auto_play = True
+        self.redirect_to_home_on_end = True
         self.watchdog_running = False
         self.last_event_time = 0
         if config:
             self.mute_ads = config.mute_ads
             self.skip_ads = config.skip_ads
             self.auto_play = config.auto_play
+            self.redirect_to_home_on_end = config.redirect_to_home_on_end
         self._command_mutex = asyncio.Lock()
 
     async def _handle_playback_state_event(self, event: PlaybackStateEvent) -> None:
@@ -235,7 +237,13 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 if data["reason"] == "disconnectedByUserScreenInitiated":  # Short playing?
                     self.shorts_disconnected = True
         elif event_type == "onAutoplayModeChanged":
-            create_task(self.set_auto_play_mode(self.auto_play))
+            if self.auto_play:
+                # Always enable autoplay when auto_play is True
+                create_task(self.set_auto_play_mode(True))
+            elif self.redirect_to_home_on_end:
+                # Only disable autoplay (causing redirect) when explicitly requested
+                create_task(self.set_auto_play_mode(False))
+            # else: Don't call set_auto_play_mode, letting YouTube use default behavior
 
         elif event_type == "onPlaybackSpeedChanged":
             data = args[0]


### PR DESCRIPTION
Introduce new config option redirect_to_home_on_end (default true); add redirect_to_home_on_end across the app:
- Added `redirect_to_home_on_end` (default: `True`) to `Config` class in `config.py`
- Added `redirect_to_home_on_end` to config template in `config_setup.py`
- Exposed `redirect_to_home_on_end` in setup wizard:
  - Added CLI prompt for `redirect_to_home_on_end` in `setup_wizard.py`
  - Added UI checkbox for `redirect_to_home_on_end` in `setup_wizard.py`
- Threaded `redirect_to_home_on_end` into `YtLounge`:
  - Updated autoplay manager UI text and handler (renamed `changed_skip` -> `changed_autoplay`)
  - Added new handler for redirect checkbox in `setup_wizard.py`
  - Added conditional check for `redirect_to_home_on_end` in `onAutoplayModeChanged` handler in `ytlounge.py`
- YtLounge now respects `redirect_to_home_on_end` flag when handling autoplay mode changes to optionally avoid calling `set_auto_play_mode` when redirect is disabled

Related to #391