### PR TITLE
Add closed_captions config option

### DIFF
--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -6,7 +6,7 @@ from . import api_helpers
 from .constants import SponsorBlock_api
 
 # Constants for user input prompts
-USE_PROXY_PROMPT = "Do you want to use system-wide proxy? (y/N)"
+USE_PROXY_PROMPT = "Do you want to use system-wide proxy? (y/N) "
 ATVS_REMOVAL_PROMPT = (
     "Do you want to remove the legacy 'atvs' entry (the app won't start with it present)? (y/N) "
 )
@@ -26,9 +26,9 @@ SEARCH_CHANNEL_PROMPT = 'Enter a channel name or "/exit" to exit: '
 SELECT_CHANNEL_PROMPT = "Select one option of the above [0-6]: "
 ENTER_CHANNEL_ID_PROMPT = "Enter a channel ID: "
 ENTER_CUSTOM_CHANNEL_NAME_PROMPT = "Enter the channel name: "
-MINIMUM_SKIP_PROMPT = "Do you want to specify a minimum length of segment to skip? (y/N)"
+MINIMUM_SKIP_PROMPT = "Do you want to specify a minimum length of segment to skip? (y/N) "
 MINIMUM_SKIP_SPECIFICATION_PROMPT = (
-    "Enter minimum length of segment to skip in seconds (enter 0 to disable):"
+    "Enter minimum length of segment to skip in seconds (enter 0 to disable): "
 )
 REPORT_SKIPPED_SEGMENTS_PROMPT = (
     "Do you want to report skipped segments to sponsorblock. Only the segment"
@@ -37,6 +37,8 @@ REPORT_SKIPPED_SEGMENTS_PROMPT = (
 MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
+CLOSED_CAPTIONS_PROMPT = "Do you want to enable Closed Captions? (y/N) "
+CLOSED_CAPTIONS_LANGUAGE_PROMPT = "Enter language code (e.g. en, de, fr): "
 ENTER_SPONSORBLOCK_API_PROMPT = f"Enter SponsorBlock API URL (default: {SponsorBlock_api}): "
 
 
@@ -208,6 +210,12 @@ def main(config, debug: bool) -> None:
 
     choice = get_yn_input(AUTOPLAY_PROMPT)
     config.auto_play = choice != "n"
+
+    choice = get_yn_input(CLOSED_CAPTIONS_PROMPT)
+    if choice == "y":
+        config.closed_captions = input(CLOSED_CAPTIONS_LANGUAGE_PROMPT)
+    else:
+        config.closed_captions = ""
 
     # SponsorBlock API URL
     api_url = input(ENTER_SPONSORBLOCK_API_PROMPT).strip()

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -52,6 +52,7 @@ class Config:
         self.skip_ads = False
         self.minimum_skip_length = 1
         self.auto_play = True
+        self.closed_captions = ""
         self.join_name = "iSponsorBlockTV"
         self.use_proxy = False
         self.sponsorblock_api_url = SponsorBlock_api

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -1037,6 +1037,7 @@ class AutoPlayManager(Vertical):
     def changed_skip(self, event: Checkbox.Changed):
         self.config.auto_play = event.checkbox.value
 
+
 class ClosedCaptionsManager(Vertical):
     """Manager for closed captions."""
 
@@ -1060,6 +1061,7 @@ class ClosedCaptionsManager(Vertical):
     @on(Input.Changed, "#closed-captions-input")
     def changed_closed_captions(self, event: Input.Changed):
         self.config.closed_captions = event.input.value
+
 
 class UseProxyManager(Vertical):
     """Manager for proxy use, allows enabling/disabling use of proxy."""
@@ -1159,7 +1161,9 @@ class ISponsorBlockTVSetup(App):
             )
             yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
             yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
-            yield ClosedCaptionsManager(config=self.config, id="closed-captions-manager", classes="container")
+            yield ClosedCaptionsManager(
+                config=self.config, id="closed-captions-manager", classes="container"
+            )
             yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
             yield SponsorBlockApiUrlManager(
                 config=self.config, id="sponsorblock-api-url-manager", classes="container"

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -1037,6 +1037,29 @@ class AutoPlayManager(Vertical):
     def changed_skip(self, event: Checkbox.Changed):
         self.config.auto_play = event.checkbox.value
 
+class ClosedCaptionsManager(Vertical):
+    """Manager for closed captions."""
+
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("Closed Captions", classes="title")
+        yield Label(
+            "This feature allows you to set preferred closed captions language",
+            classes="subtitle",
+            id="closed-captions-subtitle",
+        )
+        yield Input(
+            value=self.config.closed_captions,
+            placeholder="Enter language code (e.g. en, de, fr)",
+            id="closed-captions-input",
+        )
+
+    @on(Input.Changed, "#closed-captions-input")
+    def changed_closed_captions(self, event: Input.Changed):
+        self.config.closed_captions = event.input.value
 
 class UseProxyManager(Vertical):
     """Manager for proxy use, allows enabling/disabling use of proxy."""
@@ -1136,6 +1159,7 @@ class ISponsorBlockTVSetup(App):
             )
             yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
             yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
+            yield ClosedCaptionsManager(config=self.config, id="closed-captions-manager", classes="container")
             yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
             yield SponsorBlockApiUrlManager(
                 config=self.config, id="sponsorblock-api-url-manager", classes="container"

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -66,10 +66,12 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         self.auto_play = True
         self.watchdog_running = False
         self.last_event_time = 0
+        self.closed_captions = ""
         if config:
             self.mute_ads = config.mute_ads
             self.skip_ads = config.skip_ads
             self.auto_play = config.auto_play
+            self.closed_captions = config.closed_captions
         self._command_mutex = asyncio.Lock()
 
     async def _handle_playback_state_event(self, event: PlaybackStateEvent) -> None:
@@ -170,6 +172,10 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             if self.mute_ads and data.get("state", "0") == "1":
                 self.logger.info("Ad has ended, unmuting")
                 create_task(self.mute(False, override=True))
+            # Set Closed Captions when the video starts playing
+            if self.closed_captions and data.get("state", "0") == "1":
+                self.logger.info(f"Setting closed captions to {self.closed_captions} for video: {data.get('videoId')}")
+                create_task(self.set_closed_captions(self.closed_captions, data.get("videoId")))
         elif event_type == "onAdStateChange":
             data = args[0]
             if data["adState"] == "0" and data["currentTime"] != "0":  # Ad is not playing

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -175,7 +175,8 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             # Set Closed Captions when the video starts playing
             if self.closed_captions and data.get("state", "0") == "1":
                 self.logger.info(
-                    f"Setting closed captions to {self.closed_captions} for video: {data.get('videoId')}"
+                    f"Setting closed captions to {self.closed_captions} "
+                    f"for video: {data.get('videoId')}"
                 )
                 create_task(self.set_closed_captions(self.closed_captions, data.get("videoId")))
         elif event_type == "onAdStateChange":

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -174,7 +174,9 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 create_task(self.mute(False, override=True))
             # Set Closed Captions when the video starts playing
             if self.closed_captions and data.get("state", "0") == "1":
-                self.logger.info(f"Setting closed captions to {self.closed_captions} for video: {data.get('videoId')}")
+                self.logger.info(
+                    f"Setting closed captions to {self.closed_captions} for video: {data.get('videoId')}"
+                )
                 create_task(self.set_closed_captions(self.closed_captions, data.get("videoId")))
         elif event_type == "onAdStateChange":
             data = args[0]


### PR DESCRIPTION
Adds the ability to set and enable preferred closed captions (e.g. `en`, `de`) on playback.

### Changes:

- Config (`helpers.py`): Added closed_captions field (defaults to "").
- CLI Setup (`config_setup.py`): Added CLI prompts to toggle and set the language code.
- Setup Wizard (`setup_wizard.py`): Added a new graphical GUI widget (`ClosedCaptionsManager`) for configuring closed captions.
- Playback (`ytlounge.py`): Triggers `set_closed_captions` using the saved language code on `nowPlaying` events.

Related: #462 