### PR TITLE
Add opt-in pause mitigation for unrequested video auto-advance

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -14,6 +14,7 @@
     "skip_ads": true,
     "minimum_skip_length": 1,
     "auto_play": true,
+    "autoplay_block_action": "off",
     "join_name": "iSponsorBlockTV",
     "apikey": "",
     "channel_whitelist": [

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -37,6 +37,12 @@ REPORT_SKIPPED_SEGMENTS_PROMPT = (
 MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
+AUTOPLAY_BLOCK_PROMPT = (
+    "Some YouTube TV receivers auto-advance to the next video even"
+    " with autoplay disabled above. Do you want iSponsorBlockTV to"
+    " pause the video it auto-advances to when this happens? NOTE:"
+    " Try disabled initially; enable if the issue persists. (y/N) "
+)
 ENTER_SPONSORBLOCK_API_PROMPT = f"Enter SponsorBlock API URL (default: {SponsorBlock_api}): "
 
 
@@ -208,6 +214,11 @@ def main(config, debug: bool) -> None:
 
     choice = get_yn_input(AUTOPLAY_PROMPT)
     config.auto_play = choice != "n"
+
+    config.autoplay_block_action = "off"
+    if not config.auto_play:
+        choice = get_yn_input(AUTOPLAY_BLOCK_PROMPT)
+        config.autoplay_block_action = "pause" if choice == "y" else "off"
 
     # SponsorBlock API URL
     api_url = input(ENTER_SPONSORBLOCK_API_PROMPT).strip()

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -52,6 +52,10 @@ class Config:
         self.skip_ads = False
         self.minimum_skip_length = 1
         self.auto_play = True
+        # Opt-in workaround for receivers that continue to auto-advance:
+        #   "off"   - no action (default; try this first)
+        #   "pause" - pauses the video the receiver auto-advanced to
+        self.autoplay_block_action = "off"
         self.join_name = "iSponsorBlockTV"
         self.use_proxy = False
         self.sponsorblock_api_url = SponsorBlock_api

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -39,8 +39,7 @@ from . import api_helpers
 from .constants import skip_categories, SponsorBlock_api
 
 AUTOPLAY_BLOCK_TOOLTIP = (
-    "Pauses the video the receiver auto-advances to."
-    " Reactive, not guaranteed - try disabled first."
+    "Pauses the video the receiver auto-advances to. Reactive, not guaranteed - try disabled first."
 )
 
 

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -38,6 +38,11 @@ from textual_slider import Slider
 from . import api_helpers
 from .constants import skip_categories, SponsorBlock_api
 
+AUTOPLAY_BLOCK_TOOLTIP = (
+    "Pauses the video the receiver auto-advances to."
+    " Reactive, not guaranteed - try disabled first."
+)
+
 
 def _validate_pairing_code(pairing_code: str) -> bool:
     try:
@@ -1036,6 +1041,59 @@ class AutoPlayManager(Vertical):
     @on(Checkbox.Changed, "#autoplay-switch")
     def changed_skip(self, event: Checkbox.Changed):
         self.config.auto_play = event.checkbox.value
+        try:
+            block_switch = self.app.query_one("#autoplay-block-switch", Checkbox)
+        except NoMatches:
+            pass
+        else:
+            block_switch.disabled = event.checkbox.value
+            block_switch.tooltip = (
+                "Only applies when autoplay above is disabled"
+                if event.checkbox.value
+                else AUTOPLAY_BLOCK_TOOLTIP
+            )
+
+
+class AutoplayBlockActionManager(Vertical):
+    """Manager for the auto-advance pause workaround, only relevant
+    when autoplay above is disabled."""
+
+    def __init__(self, config, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.config = config
+
+    def compose(self) -> ComposeResult:
+        yield Label("Auto-advance workaround", classes="title")
+        yield Label(
+            "Some YouTube TV receivers auto-advance to the next video even"
+            " with autoplay disabled above. This pauses the video the"
+            " receiver switches to when that happens. Reactive: the wrong"
+            " video briefly starts before being paused, and on some"
+            " receivers the pause itself can be undone a few seconds"
+            " later with no action taken here. Try leaving this disabled"
+            " first; enable only if the issue persists.",
+            classes="subtitle",
+            id="autoplay-block-subtitle",
+        )
+        with Horizontal(id="autoplay-block-container"):
+            yield Checkbox(
+                value=self.config.autoplay_block_action == "pause",
+                id="autoplay-block-switch",
+                label="Pause auto-advanced videos",
+                disabled=self.config.auto_play,
+            )
+
+    def on_mount(self) -> None:
+        switch = self.query_one("#autoplay-block-switch", Checkbox)
+        switch.tooltip = (
+            "Only applies when autoplay above is disabled"
+            if self.config.auto_play
+            else AUTOPLAY_BLOCK_TOOLTIP
+        )
+
+    @on(Checkbox.Changed, "#autoplay-block-switch")
+    def changed_block_action(self, event: Checkbox.Changed):
+        self.config.autoplay_block_action = "pause" if event.checkbox.value else "off"
 
 
 class UseProxyManager(Vertical):
@@ -1136,6 +1194,9 @@ class ISponsorBlockTVSetup(App):
             )
             yield ApiKeyManager(config=self.config, id="api-key-manager", classes="container")
             yield AutoPlayManager(config=self.config, id="autoplay-manager", classes="container")
+            yield AutoplayBlockActionManager(
+                config=self.config, id="autoplay-block-manager", classes="container"
+            )
             yield UseProxyManager(config=self.config, id="useproxy-manager", classes="container")
             yield SponsorBlockApiUrlManager(
                 config=self.config, id="sponsorblock-api-url-manager", classes="container"

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -217,8 +217,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 # A tighter window already active means state "0" fired
                 # for this video; preserve it instead of loosening to 90s.
                 keep_tighter_window = (
-                    self._current_video_ended
-                    and self._current_video_ended_window == 10
+                    self._current_video_ended and self._current_video_ended_window == 10
                 )
                 if self._current_video_ended:
                     self._current_video_ended_marks += 1
@@ -238,10 +237,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 if self.auto_play:
                     pass  # autoplay is enabled, no action needed
                 elif self._current_video_ended:
-                    elapsed = (
-                        asyncio.get_running_loop().time()
-                        - self._current_video_ended_at
-                    )
+                    elapsed = asyncio.get_running_loop().time() - self._current_video_ended_at
                     if elapsed <= self._current_video_ended_window:
                         if self.autoplay_block_action == "pause":
                             self.logger.info(

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -17,6 +17,18 @@ from .constants import youtube_client_blacklist
 create_task = asyncio.create_task
 
 
+def _state_desc(state) -> str:
+    """Descriptive playback state, e.g. '1 (Playing)'.
+    pyytlounge State names differ from YouTube's own labels for 0/3:
+    0 is "ended" and 3 is "buffering" in YouTube's terminology."""
+    if state is None:
+        return "None"
+    try:
+        return f"{state} ({State.parse(state).name})"
+    except Exception:
+        return str(state)
+
+
 class PlaybackState:
     def __init__(self):
         self.currentTime = 0.0
@@ -66,10 +78,21 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         self.auto_play = True
         self.watchdog_running = False
         self.last_event_time = 0
+        # Tracks whether the current video reached its natural end, used
+        # to distinguish an auto-advance from a manual video selection.
+        self._current_video_id = None
+        self._current_video_ended = False
+        self._current_video_ended_at = 0.0
+        self._current_video_ended_window = 10
+        self._current_video_ended_marks = 0
+        # "off" (default) or "pause": pauses the video the receiver
+        # auto-advances to; see autoplay_block_action in helpers.py.
+        self.autoplay_block_action = "off"
         if config:
             self.mute_ads = config.mute_ads
             self.skip_ads = config.skip_ads
             self.auto_play = config.auto_play
+            self.autoplay_block_action = getattr(config, "autoplay_block_action", "off")
         self._command_mutex = asyncio.Lock()
 
     async def _handle_playback_state_event(self, event: PlaybackStateEvent) -> None:
@@ -161,15 +184,96 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         if event_type == "onStateChange":
             data = args[0]
             # print(data)
+            state = data.get("state")
             # Unmute when the video starts playing
-            if self.mute_ads and data["state"] == "1":
+            if self.mute_ads and state == "1":
                 create_task(self.mute(False, override=True))
+            # state "0" is the real end-of-video signal (non-repeating,
+            # fires once at currentTime == duration).
+            if state == "0":
+                self.logger.info(
+                    f"Video {self._current_video_id} reached its natural end "
+                    f"(state {_state_desc(state)})"
+                )
+                self._current_video_ended = True
+                self._current_video_ended_at = asyncio.get_running_loop().time()
+                self._current_video_ended_window = 10
+                self._current_video_ended_marks = 1
         elif event_type == "nowPlaying":
             data = args[0]
+            state = data.get("state")
+            new_video_id = data.get("videoId")
             # Unmute when the video starts playing
-            if self.mute_ads and data.get("state", "0") == "1":
+            if self.mute_ads and state == "1":
                 self.logger.info("Ad has ended, unmuting")
                 create_task(self.mute(False, override=True))
+
+            # Playlists never emit state "0" on the outgoing video;
+            # instead a bare nowPlaying (listId, no videoId) arrives.
+            # This same event also fires periodically during normal
+            # long-video playback, so it is recorded as a timestamped
+            # marker only - not acted on directly.
+            if not new_video_id and data.get("listId") and self._current_video_id:
+                # A tighter window already active means state "0" fired
+                # for this video; preserve it instead of loosening to 90s.
+                keep_tighter_window = (
+                    self._current_video_ended
+                    and self._current_video_ended_window == 10
+                )
+                if self._current_video_ended:
+                    self._current_video_ended_marks += 1
+                else:
+                    self._current_video_ended_marks = 1
+                self.logger.debug(
+                    f"Bare listId nowPlaying event for {self._current_video_id} "
+                    f"(mark {self._current_video_ended_marks}, validity 90s)"
+                )
+                self._current_video_ended = True
+                self._current_video_ended_at = asyncio.get_running_loop().time()
+                if not keep_tighter_window:
+                    self._current_video_ended_window = 90
+            elif new_video_id and new_video_id != self._current_video_id:
+                # Only treated as auto-advance if the previous video
+                # ended within its validity window.
+                if self.auto_play:
+                    pass  # autoplay is enabled, no action needed
+                elif self._current_video_ended:
+                    elapsed = (
+                        asyncio.get_running_loop().time()
+                        - self._current_video_ended_at
+                    )
+                    if elapsed <= self._current_video_ended_window:
+                        if self.autoplay_block_action == "pause":
+                            self.logger.info(
+                                f"Auto-advance detected: {self._current_video_id} "
+                                f"-> {new_video_id} (state {_state_desc(state)}), "
+                                f"autoplay disabled; pausing"
+                            )
+                            create_task(self.pause())
+                        else:
+                            self.logger.info(
+                                f"Auto-advance detected: {self._current_video_id} "
+                                f"-> {new_video_id}, autoplay disabled; "
+                                f"autoplay_block_action is 'off', no action taken"
+                            )
+                    else:
+                        self.logger.info(
+                            f"End-of-video marker for {self._current_video_id} "
+                            f"expired ({elapsed:.1f}s elapsed, "
+                            f"{self._current_video_ended_window}s window, "
+                            f"{self._current_video_ended_marks} mark(s)); "
+                            f"{new_video_id} treated as a manual selection"
+                        )
+                else:
+                    self.logger.info(
+                        f"New video {new_video_id} started (state "
+                        f"{_state_desc(state)}) following "
+                        f"{self._current_video_id}, which had not ended; "
+                        f"treated as a manual selection"
+                    )
+                self._current_video_id = new_video_id
+                self._current_video_ended = False
+                self._current_video_ended_marks = 0
         elif event_type == "onAdStateChange":
             data = args[0]
             if data["adState"] == "0" and data["currentTime"] != "0":  # Ad is not playing
@@ -190,7 +294,9 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             self.volume_state = args[0]
         # Gets segments for the next video before it starts playing
         elif event_type == "autoplayUpNext":
-            if len(args) > 0 and (vid_id := args[0]["videoId"]):  # if video id is not empty
+            # autoplayUpNext fires constantly during normal playback and
+            # on manual selection - not a reliable auto-advance signal.
+            if len(args) > 0 and (vid_id := args[0].get("videoId")):
                 self.logger.info(f"Getting segments for next video: {vid_id}")
                 create_task(self.api_helper.get_segments(vid_id))
 
@@ -228,8 +334,14 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 data = args[0]
                 video_id_saved = data.get("videoId", None)
                 self.shorts_disconnected = False
+                # App-initiated play, not an auto-advance.
+                self._current_video_ended = False
+                self._current_video_ended_marks = 0
+                self._current_video_id = video_id_saved
                 create_task(self.play_video(video_id_saved))
         elif event_type == "loungeScreenDisconnected":
+            self._current_video_ended = False
+            self._current_video_ended_marks = 0
             if args:  # Sometimes it's empty
                 data = args[0]
                 if data["reason"] == "disconnectedByUserScreenInitiated":  # Short playing?


### PR DESCRIPTION
Relates to #153, #190, #283, #391, #471.

Some YouTube TV receivers keep playing the next video even when autoplay is turned off in `config.json` and on the TV app itself. This adds an opt-in `autoplay_block_action` setting (`"off"` by default, `"pause"` to enable) that catches those transitions and pauses the new video. Both CLI (`config_setup.py`) and TUI (`setup_wizard.py`) setup wizards prompt for it now if autoplay is disabled.

**How detection works**:
Listening to `autoplayUpNext` directly causes constant misfires because current YouTube TV app versions emit it continuously during normal playback and manual navigation. Instead, this tracks whether the outgoing video actually finished before a new `videoId` appears:
- **Standalone videos**: Uses `state "0"` (`ended`) with a short 10s validity window.
- **Playlists (Watch Later, etc.)**: YouTube TV doesn't send `state "0"` inside playlist queues. It sends a bare `nowPlaying` payload (`listId` present, no `videoId`) before transitioning. Since that same event also pings periodically during long videos, it's used as a timestamped marker with a 90s window. If a new `videoId` loads within that window, it triggers the pause.
- If both signals show up for the same video, the tighter 10s window is kept so manual picks aren't flagged by mistake.

**Notes on `autoplay-improved` and active navigation**:
Testing showed that dropping the `que` capability at connect time (`vsp` only) fixes autoplay for standalone videos by returning to the home screen. However, playlists still auto-advance regardless—playlist queueing appears to bypass whatever `que` controls. This PR handles that remaining playlist gap and acts as a fallback if the capability change doesn't work on a given TV.

I also tried sending synthetic `BACK` keypresses to force the app back to the playlist UI, but it was unreliable (sometimes doing nothing, other times triggering a disconnect loop). Pausing the new video directly avoids messing with remote input or UI focus.

**Testing**:
Tested on an Apple TV across several hours of standalone and Watch Later playback, explicitly trying to trigger false positives via manual search, home screen picks, and end-card related videos. Unit tests cover signal overlap, periodic playlist pings, watchdog reconnects, ad breaks, TUI toggle/tooltip states, and old `config.json` compatibility.