### PR TITLE
Add ad_volume option to lower volume during ads instead of muting

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -11,6 +11,7 @@
     ],
     "skip_count_tracking": true,
     "mute_ads": true,
+    "ad_volume": null,
     "skip_ads": true,
     "minimum_skip_length": 1,
     "auto_play": true,

--- a/src/iSponsorBlockTV/config_setup.py
+++ b/src/iSponsorBlockTV/config_setup.py
@@ -35,6 +35,10 @@ REPORT_SKIPPED_SEGMENTS_PROMPT = (
     " UUID will be sent? (Y/n) "
 )
 MUTE_ADS_PROMPT = "Do you want to mute native YouTube ads automatically? (y/N) "
+AD_VOLUME_PROMPT = (
+    "Enter the volume to set during ads (0-100), or leave empty to mute instead."
+    " Useful if muting an ad is too abrupt: "
+)
 SKIP_ADS_PROMPT = "Do you want to skip native YouTube ads automatically? (y/N) "
 AUTOPLAY_PROMPT = "Do you want to enable autoplay? (Y/n) "
 ENTER_SPONSORBLOCK_API_PROMPT = f"Enter SponsorBlock API URL (default: {SponsorBlock_api}): "
@@ -202,6 +206,17 @@ def main(config, debug: bool) -> None:
 
     choice = get_yn_input(MUTE_ADS_PROMPT)
     config.mute_ads = choice == "y"
+
+    if config.mute_ads:
+        while True:
+            ad_volume = input(AD_VOLUME_PROMPT).strip()
+            if not ad_volume:
+                config.ad_volume = None
+                break
+            if ad_volume.isdigit() and int(ad_volume) <= 100:
+                config.ad_volume = int(ad_volume)
+                break
+            print("You entered an invalid volume, try again.")
 
     choice = get_yn_input(SKIP_ADS_PROMPT)
     config.skip_ads = choice == "y"

--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -49,6 +49,7 @@ class Config:
         self.channel_whitelist = []
         self.skip_count_tracking = True
         self.mute_ads = False
+        self.ad_volume = None  # None = mute ads instead of lowering the volume
         self.skip_ads = False
         self.minimum_skip_length = 1
         self.auto_play = True
@@ -78,6 +79,10 @@ class Config:
         self.devices = [Device(i) for i in self.devices]
         if not self.apikey and self.channel_whitelist:
             raise ValueError("No youtube API key found and channel whitelist is not empty")
+        if self.ad_volume is not None and not (
+            isinstance(self.ad_volume, int) and 0 <= self.ad_volume <= 100
+        ):
+            raise ValueError("ad_volume must be a number between 0 and 100")
         if self.skip_categories is None:
             self.skip_categories = ["sponsor"]
             print("No categories found, using default: sponsor")

--- a/src/iSponsorBlockTV/setup_wizard.py
+++ b/src/iSponsorBlockTV/setup_wizard.py
@@ -938,10 +938,39 @@ class AdSkipMuteManager(Vertical):
                 id="mute-ads-switch",
                 label="Enable muting ads",
             )
+        yield Label(
+            (
+                "Muting an ad cuts the sound dead. Set a volume below to lower the"
+                " volume during ads instead of muting; the previous volume is"
+                " restored when the ad ends."
+            ),
+            classes="subtitle",
+        )
+        yield Input(
+            placeholder="Ad volume 0-100 (empty to mute instead)",
+            id="ad-volume-input",
+            value="" if self.config.ad_volume is None else str(self.config.ad_volume),
+            validators=[
+                Function(
+                    lambda user_input: (
+                        not user_input or (user_input.isdigit() and int(user_input) <= 100)
+                    ),
+                    "Please enter a volume between 0 and 100",
+                )
+            ],
+        )
 
     @on(Checkbox.Changed, "#mute-ads-switch")
     def changed_mute(self, event: Checkbox.Changed):
         self.config.mute_ads = event.checkbox.value
+
+    @on(Input.Changed, "#ad-volume-input")
+    def changed_ad_volume(self, event: Input.Changed):
+        value = event.input.value.strip()
+        if value.isdigit() and int(value) <= 100:
+            self.config.ad_volume = int(value)
+        else:
+            self.config.ad_volume = None
 
     @on(Checkbox.Changed, "#skip-ads-switch")
     def changed_skip(self, event: Checkbox.Changed):

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -55,6 +55,8 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         self.auth.lounge_id_token = None
         self.api_helper = api_helper
         self.volume_state = {}
+        self.ad_volume = None
+        self.volume_before_ad = None
         self.playback_speed = 1.0
         self.subscribe_task = None
         self.subscribe_task_watchdog = None
@@ -68,6 +70,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         self.last_event_time = 0
         if config:
             self.mute_ads = config.mute_ads
+            self.ad_volume = config.ad_volume
             self.skip_ads = config.skip_ads
             self.auto_play = config.auto_play
         self._command_mutex = asyncio.Lock()
@@ -222,6 +225,10 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                         self._sid = None
                         self._gsession = None  # Force disconnect
                         return
+            # The device only reports its volume when something changes it, so
+            # ask now: without it the first ad has no volume to come back to.
+            if self.ad_volume is not None and "volume" not in self.volume_state:
+                create_task(self.get_volume())
 
         elif event_type == "onSubtitlesTrackChanged":
             if self.shorts_disconnected:
@@ -247,6 +254,10 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
     async def set_volume(self, volume: int) -> None:
         await self._command("setVolume", {"volume": volume})
 
+    # Ask the device for its volume, answered with an onVolumeChanged event
+    async def get_volume(self) -> bool:
+        return await self._command("getVolume")
+
     async def mute(self, mute: bool, override: bool = False) -> None:
         """
         Mute or unmute the device (if the device already
@@ -258,6 +269,15 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
 
         TODO: Only works if the device is subscribed to the lounge
         """
+        # Falls through to the muted flag while the device volume is still
+        # unknown, as there would be nothing to restore once the ad ends.
+        if self.ad_volume is not None:
+            if mute and "volume" in self.volume_state:
+                await self._duck_volume(True)
+                return
+            if not mute and self.volume_before_ad is not None:
+                await self._duck_volume(False)
+                return
         if mute:
             mute_str = "true"
         else:
@@ -269,6 +289,35 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                 "setVolume",
                 {"volume": self.volume_state.get("volume", 100), "muted": mute_str},
             )
+
+    async def _duck_volume(self, mute: bool) -> None:
+        """
+        Silence an ad by lowering the volume to `ad_volume` and restore the
+        previous volume afterwards, leaving the muted flag alone.
+
+        Used instead of muting when `ad_volume` is set, for when cutting the
+        sound dead is more jarring than the ad and a barely audible floor is
+        preferred. Only called by `mute`, which is what checks there is a volume
+        to lower and to restore.
+
+        The volume to restore is saved when the ad starts and cannot be read
+        back at the end: the device reports the lowered volume in an
+        `onVolumeChanged` event, so restoring from `volume_state` would leave it
+        at the ad volume.
+
+        :param bool mute: True when an ad starts, False when it ends
+        """
+        if mute:
+            if self.volume_before_ad is not None:  # Already lowered
+                return
+            self.volume_before_ad = self.volume_state["volume"]
+            volume = self.ad_volume
+        else:
+            volume = self.volume_before_ad
+            self.volume_before_ad = None
+        self.volume_state["volume"] = volume
+        self.logger.info("Setting volume to %s", volume)
+        await self._command("setVolume", {"volume": volume})
 
     async def play_video(self, video_id: str) -> bool:
         return await self._command("setPlaylist", {"videoId": video_id})


### PR DESCRIPTION
Muting an ad cuts the sound dead, and I find that sudden silence more jarring than the ad. I'd rather drop the volume to a few percent and keep a floor.

Adds an optional `ad_volume` (0-100). When set, an ad drops the volume to that value instead of flipping the mute flag, and the volume in place before the ad is restored when it ends. Left unset, nothing changes.

Three things it has to handle:

- the device echoes the lowered volume back in `onVolumeChanged`, so the restore point is saved once at the start of the ad instead of being read back from `volume_state`;
- the device only reports its volume when something changes it, so `getVolume` is sent once the lounge session is up - otherwise the first ad after connecting has nothing to come back to;
- if the volume is still unknown anyway, it falls back to the muted flag rather than guessing a volume to restore.

Wired into both configurators and the template.

Running on an Apple TV (tvOS 26.6) with `ad_volume` set: `loungeStatus` -> `getVolume` -> `onVolumeChanged {'volume': '100'}` in 100 ms, then ads play at the low volume and 100 comes back when they end.
